### PR TITLE
Support controller cmds as sub-cmds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.1",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
-        "@tableland/sdk": "^2.0.2",
+        "@tableland/sdk": "^3.0.0",
         "dotenv": "^16.0.1",
         "ethers": "^5.6.9",
         "node-fetch": "^2.6.7",
@@ -853,20 +853,20 @@
       "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
     },
     "node_modules/@tableland/evm": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-2.0.2.tgz",
-      "integrity": "sha512-ZzYEfqQC1blUS0Ao5oGnxb4cDZt90jVJ3JtIAhcRJd39HGVAo6B0wA2pFreb5yfveT+Jji5HzM3OP97NK/71ew==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-2.0.3.tgz",
+      "integrity": "sha512-bn++kCdobMD9iZEczPSMRzRlbTXgB3ew9DsjSfmm1mQm3tlGEk01NGO0ZM/0plTuTQ2P7Kf9ppFYeITw4QKi7w==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@tableland/sdk": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-2.0.2.tgz",
-      "integrity": "sha512-8cxcI3sk7dVaaGKEX6pAs2AVfLffTuUmQZ9unzcLIn9AJfJ8J8LgWRJOHNAIj6Fy/9Bx873CzFsjf+FuSWuxdQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-3.0.0.tgz",
+      "integrity": "sha512-tMEUB2aM6H9k+px9edljd/RdnVvdSWQAYZKSQxaKTrRJA+bHnKprfWrFRu7Z3bqLnHGqx7KvH/FPtWMrypIijw==",
       "dependencies": {
         "@stablelib/base64": "^1.0.1",
-        "@tableland/evm": "^2.0.2",
+        "@tableland/evm": "^2.0.3",
         "camelcase": "^6.3.0",
         "ethers": "^5.5.2",
         "siwe": "^1.1.6"
@@ -5136,17 +5136,17 @@
       "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
     },
     "@tableland/evm": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-2.0.2.tgz",
-      "integrity": "sha512-ZzYEfqQC1blUS0Ao5oGnxb4cDZt90jVJ3JtIAhcRJd39HGVAo6B0wA2pFreb5yfveT+Jji5HzM3OP97NK/71ew=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-2.0.3.tgz",
+      "integrity": "sha512-bn++kCdobMD9iZEczPSMRzRlbTXgB3ew9DsjSfmm1mQm3tlGEk01NGO0ZM/0plTuTQ2P7Kf9ppFYeITw4QKi7w=="
     },
     "@tableland/sdk": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-2.0.2.tgz",
-      "integrity": "sha512-8cxcI3sk7dVaaGKEX6pAs2AVfLffTuUmQZ9unzcLIn9AJfJ8J8LgWRJOHNAIj6Fy/9Bx873CzFsjf+FuSWuxdQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-3.0.0.tgz",
+      "integrity": "sha512-tMEUB2aM6H9k+px9edljd/RdnVvdSWQAYZKSQxaKTrRJA+bHnKprfWrFRu7Z3bqLnHGqx7KvH/FPtWMrypIijw==",
       "requires": {
         "@stablelib/base64": "^1.0.1",
-        "@tableland/evm": "^2.0.2",
+        "@tableland/evm": "^2.0.3",
         "camelcase": "^6.3.0",
         "ethers": "^5.5.2",
         "siwe": "^1.1.6"

--- a/package.json
+++ b/package.json
@@ -52,13 +52,10 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@tableland/sdk": "^2.0.2",
+    "@tableland/sdk": "^3.0.0",
     "dotenv": "^16.0.1",
     "ethers": "^5.6.9",
     "node-fetch": "^2.6.7",
     "yargs": "^17.5.1"
-  },
-  "contributors": [
-    "Carson Farmer <carson@textile.io>"
-  ]
+  }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,12 @@ const _ = yargs(hideBin(process.argv))
     description: "The EVM compatible chain to target",
     default: "ethereum-goerli",
   })
+  .option("r", {
+    alias: "rpcRelay",
+    type: "boolean",
+    description: "Whether writes should be relayed via a validator",
+    default: true,
+  })
   .options({
     alchemy: {
       type: "string",

--- a/src/commands/controller.ts
+++ b/src/commands/controller.ts
@@ -1,0 +1,140 @@
+import type yargs from "yargs";
+import type { Arguments, CommandBuilder } from "yargs";
+import { connect, ConnectOptions, ChainName } from "@tableland/sdk";
+import { getWallet } from "../utils";
+
+type Options = {
+  // Local
+  name: string;
+  controller: string;
+
+  // Global
+  privateKey: string;
+  chain: ChainName;
+  alchemy: string | undefined;
+  infura: string | undefined;
+  etherscan: string | undefined;
+};
+
+export const command = "controller <sub>";
+export const desc =
+  "Get, set, and lock the controller contract for a given table";
+
+export const builder: CommandBuilder<Options, Options> = (yargs) =>
+  yargs
+    .command(
+      "get <name>",
+      "Get the current controller address for a table",
+      (yargs) =>
+        yargs.positional("name", {
+          type: "string",
+          description: "The target table name",
+        }) as yargs.Argv<Options>,
+      async (argv) => {
+        const { name, chain, privateKey, etherscan, infura, alchemy } = argv;
+
+        try {
+          const signer = getWallet({
+            privateKey,
+            chain,
+            infura,
+            etherscan,
+            alchemy,
+          });
+          const options: ConnectOptions = {
+            chain,
+            signer,
+          };
+          const res = await connect(options).getController(name);
+          const out = JSON.stringify(res, null, 2);
+          console.log(out);
+          process.exit(0);
+        } catch (err: any) {
+          console.error(err.message);
+          process.exit(1);
+        }
+      }
+    )
+    .command(
+      "set <controller> <name>",
+      "Set the controller address for a table",
+      (yargs) =>
+        yargs
+          .positional("controller", {
+            type: "string",
+            description: "The target controller address",
+          })
+          .positional("name", {
+            type: "string",
+            description: "The target table name",
+          }) as yargs.Argv<Options>,
+      async (argv) => {
+        const {
+          name,
+          controller,
+          chain,
+          privateKey,
+          etherscan,
+          infura,
+          alchemy,
+        } = argv;
+
+        try {
+          const signer = getWallet({
+            privateKey,
+            chain,
+            infura,
+            etherscan,
+            alchemy,
+          });
+          const options: ConnectOptions = {
+            chain,
+            signer,
+          };
+          const res = await connect(options).setController(controller, name);
+          const out = JSON.stringify(res, null, 2);
+          console.log(out);
+          process.exit(0);
+        } catch (err: any) {
+          console.error(err.message);
+          process.exit(1);
+        }
+      }
+    )
+    .command(
+      "lock <name>",
+      "Lock the controller address for a table",
+      (yargs) =>
+        yargs.positional("name", {
+          type: "string",
+          description: "The target table name",
+        }) as yargs.Argv<Options>,
+      async (argv) => {
+        const { name, chain, privateKey, etherscan, infura, alchemy } = argv;
+
+        try {
+          const signer = getWallet({
+            privateKey,
+            chain,
+            infura,
+            etherscan,
+            alchemy,
+          });
+          const options: ConnectOptions = {
+            chain,
+            signer,
+          };
+          const res = await connect(options).lockController(name);
+          const out = JSON.stringify(res, null, 2);
+          console.log(out);
+          process.exit(0);
+        } catch (err: any) {
+          console.error(err.message);
+          process.exit(1);
+        }
+      }
+    );
+
+export const handler = async (argv: Arguments<Options>): Promise<void> => {
+  // noop
+};

--- a/src/commands/controller.ts
+++ b/src/commands/controller.ts
@@ -9,6 +9,7 @@ type Options = {
   controller: string;
 
   // Global
+  rpcRelay: boolean;
   privateKey: string;
   chain: ChainName;
   alchemy: string | undefined;
@@ -31,7 +32,20 @@ export const builder: CommandBuilder<Options, Options> = (yargs) =>
           description: "The target table name",
         }) as yargs.Argv<Options>,
       async (argv) => {
-        const { name, chain, privateKey, etherscan, infura, alchemy } = argv;
+        const {
+          name,
+          chain,
+          privateKey,
+          etherscan,
+          infura,
+          alchemy,
+          rpcRelay,
+        } = argv;
+
+        if (rpcRelay) {
+          console.error("Cannot relay controller calls via RPC");
+          process.exit(1);
+        }
 
         try {
           const signer = getWallet({
@@ -77,7 +91,13 @@ export const builder: CommandBuilder<Options, Options> = (yargs) =>
           etherscan,
           infura,
           alchemy,
+          rpcRelay,
         } = argv;
+
+        if (rpcRelay) {
+          console.error("Cannot relay controller calls via RPC");
+          process.exit(1);
+        }
 
         try {
           const signer = getWallet({
@@ -110,7 +130,20 @@ export const builder: CommandBuilder<Options, Options> = (yargs) =>
           description: "The target table name",
         }) as yargs.Argv<Options>,
       async (argv) => {
-        const { name, chain, privateKey, etherscan, infura, alchemy } = argv;
+        const {
+          name,
+          chain,
+          privateKey,
+          etherscan,
+          infura,
+          alchemy,
+          rpcRelay,
+        } = argv;
+
+        if (rpcRelay) {
+          console.error("Cannot relay controller calls via RPC");
+          process.exit(1);
+        }
 
         try {
           const signer = getWallet({

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,8 +1,7 @@
 import type yargs from "yargs";
 import type { Arguments, CommandBuilder } from "yargs";
-import { Wallet, providers, getDefaultProvider } from "ethers";
 import { connect, ConnectOptions, ChainName } from "@tableland/sdk";
-import getChains from "../chains";
+import { getWallet } from "../utils";
 
 type Options = {
   // Local
@@ -10,6 +9,7 @@ type Options = {
   prefix: string | undefined;
 
   // Global
+  rpcRelay: boolean;
   privateKey: string;
   chain: ChainName;
   alchemy: string | undefined;
@@ -32,51 +32,34 @@ export const builder: CommandBuilder<Options, Options> = (yargs) =>
     }) as yargs.Argv<Options>;
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
-  const { schema, prefix, privateKey, chain, alchemy, infura, etherscan } =
-    argv;
-
-  if (!privateKey) {
-    console.error("missing required flag (`-k` or `--privateKey`)\n");
-    process.exit(1);
-  }
-  const network = getChains()[chain];
-  if (!network) {
-    console.error("unsupported chain (see `chains` command for details)\n");
-    process.exit(1);
-  }
-
-  const wallet = new Wallet(privateKey);
-  let provider: providers.BaseProvider | undefined;
-  if (chain === "local-tableland") {
-    provider = new providers.JsonRpcProvider({
-      url: "http://localhost:8545",
-    });
-  } else if (infura) {
-    provider = new providers.InfuraProvider(network, infura);
-  } else if (etherscan) {
-    provider = new providers.EtherscanProvider(network, etherscan);
-  } else if (alchemy) {
-    provider = new providers.AlchemyProvider(network, alchemy);
-  } else {
-    // This will be significantly rate limited, but we only need to run it once
-    provider = getDefaultProvider(network);
-  }
-  if (!provider) {
-    console.error("unable to create ETH API provider\n");
-    process.exit(1);
-  }
-
-  const options: ConnectOptions = {
+  const {
+    schema,
+    prefix,
+    privateKey,
     chain,
-    signer: wallet.connect(provider),
-  };
-  const tbl = await connect(options);
-  const res = await tbl.create(schema, prefix);
-  const out = JSON.stringify(
-    { ...res, tableId: (res.tableId ?? "").toString() },
-    null,
-    2
-  );
-  console.log(out);
-  process.exit(0);
+    alchemy,
+    infura,
+    etherscan,
+    rpcRelay,
+  } = argv;
+
+  try {
+    const signer = getWallet({ privateKey, chain, infura, etherscan, alchemy });
+    const options: ConnectOptions = {
+      chain,
+      rpcRelay,
+      signer,
+    };
+    const res = await connect(options).create(schema, { prefix });
+    const out = JSON.stringify(
+      { ...res, tableId: (res.tableId ?? "").toString() },
+      null,
+      2
+    );
+    console.log(out);
+    process.exit(0);
+  } catch (err: any) {
+    console.error(err.message);
+    process.exit(1);
+  }
 };

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -47,10 +47,15 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
     process.exit(1);
   }
 
-  const res = await fetch(
-    `${network.host}/chain/${network.chainId}/tables/${id}`
-  );
-  const out = JSON.stringify(await res.json(), null, 2);
-  console.log(out);
-  process.exit(0);
+  try {
+    const res = await fetch(
+      `${network.host}/chain/${network.chainId}/tables/${id}`
+    );
+    const out = JSON.stringify(await res.json(), null, 2);
+    console.log(out);
+    process.exit(0);
+  } catch (err: any) {
+    console.error(err.message);
+    process.exit(1);
+  }
 };

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -42,10 +42,15 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
     process.exit(1);
   }
 
-  const res = await fetch(
-    `${network.host}/chain/${network.chainId}/tables/controller/${address}`
-  );
-  const out = JSON.stringify(await res.json(), null, 2);
-  console.log(out);
-  process.exit(0);
+  try {
+    const res = await fetch(
+      `${network.host}/chain/${network.chainId}/tables/controller/${address}`
+    );
+    const out = JSON.stringify(await res.json(), null, 2);
+    console.log(out);
+    process.exit(0);
+  } catch (err: any) {
+    console.error(err.message);
+    process.exit(1);
+  }
 };

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -32,13 +32,13 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
     if (privateKey) {
       address = new Wallet(privateKey).address;
     } else {
-      console.error("must supply `--privateKey` or `address` positional\n");
+      console.error("must supply `--privateKey` or `address` positional");
       process.exit(1);
     }
   }
   const network = getChains()[chain];
   if (!network) {
-    console.error("unsupported chain (see `chains` command for details)\n");
+    console.error("unsupported chain (see `chains` command for details)");
     process.exit(1);
   }
 

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -44,14 +44,19 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   const options: ConnectOptions = {
     chain,
   };
-  const res = await connect(options).read(query);
-  const formatted = format === "raw" ? res : resultsToObjects(res);
+  try {
+    const res = await connect(options).read(query);
+    const formatted = format === "raw" ? res : resultsToObjects(res);
 
-  if (format.startsWith("tab")) {
-    console.table(formatted);
-  } else {
-    const out = JSON.stringify(formatted, null, 2);
-    console.log(out);
+    if (format.startsWith("tab")) {
+      console.table(formatted);
+    } else {
+      const out = JSON.stringify(formatted, null, 2);
+      console.log(out);
+    }
+    process.exit(0);
+  } catch (err: any) {
+    console.error(err.message);
+    process.exit(1);
   }
-  process.exit(0);
 };

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -44,8 +44,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   const options: ConnectOptions = {
     chain,
   };
-  const tbl = await connect(options);
-  const res = await tbl.read(query);
+  const res = await connect(options).read(query);
   const formatted = format === "raw" ? res : resultsToObjects(res);
 
   if (format.startsWith("tab")) {

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -9,6 +9,7 @@ type Options = {
   hash: string;
 
   // Global
+  rpcRelay: boolean;
   privateKey: string;
   chain: ChainName;
 };
@@ -24,7 +25,7 @@ export const builder: CommandBuilder<Options, Options> = (yargs) =>
   }) as yargs.Argv<Options>;
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
-  const { hash, privateKey, chain } = argv;
+  const { hash, privateKey, chain, rpcRelay } = argv;
 
   if (!privateKey) {
     console.error("missing required flag (`-k` or `--privateKey`)\n");
@@ -38,6 +39,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
 
   const options: ConnectOptions = {
     chain,
+    rpcRelay,
     signer: new Wallet(privateKey),
   };
   const res = await connect(options).receipt(hash);

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -40,8 +40,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
     chain,
     signer: new Wallet(privateKey),
   };
-  const tbl = await connect(options);
-  const res = await tbl.receipt(hash);
+  const res = await connect(options).receipt(hash);
   const out = JSON.stringify(res, null, 2);
   console.log(out);
   process.exit(0);

--- a/src/commands/write.ts
+++ b/src/commands/write.ts
@@ -9,6 +9,7 @@ type Options = {
   statement: string;
 
   // Global
+  rpcRelay: boolean;
   privateKey: string;
   chain: ChainName;
 };
@@ -23,7 +24,7 @@ export const builder: CommandBuilder<Options, Options> = (yargs) =>
   }) as yargs.Argv<Options>;
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
-  const { statement, privateKey, chain } = argv;
+  const { statement, privateKey, chain, rpcRelay } = argv;
 
   if (!privateKey) {
     console.error("missing required flag (`-k` or `--privateKey`)\n");
@@ -37,10 +38,10 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
 
   const options: ConnectOptions = {
     chain,
+    rpcRelay,
     signer: new Wallet(privateKey),
   };
-  const tbl = await connect(options);
-  const res = await tbl.write(statement);
+  const res = await connect(options).write(statement);
   const out = JSON.stringify(res, null, 2);
   process.stdout.write(`${out}\n`);
   process.exit(0);

--- a/src/commands/write.ts
+++ b/src/commands/write.ts
@@ -41,8 +41,13 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
     rpcRelay,
     signer: new Wallet(privateKey),
   };
-  const res = await connect(options).write(statement);
-  const out = JSON.stringify(res, null, 2);
-  process.stdout.write(`${out}\n`);
-  process.exit(0);
+  try {
+    const res = await connect(options).write(statement);
+    const out = JSON.stringify(res, null, 2);
+    console.log(out);
+    process.exit(0);
+  } catch (err: any) {
+    console.error(err.message);
+    process.exit(1);
+  }
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,48 @@
+import { Wallet, providers, getDefaultProvider } from "ethers";
+import { ChainName } from "@tableland/sdk";
+import getChains from "./chains";
+
+export interface Options {
+  privateKey: string;
+  chain: ChainName;
+  alchemy: string | undefined;
+  infura: string | undefined;
+  etherscan: string | undefined;
+}
+
+export function getWallet({
+  privateKey,
+  chain,
+  alchemy,
+  infura,
+  etherscan,
+}: Options): Wallet {
+  if (!privateKey) {
+    throw new Error("missing required flag (`-k` or `--privateKey`)");
+  }
+  const network = getChains()[chain];
+  if (!network) {
+    throw new Error("unsupported chain (see `chains` command for details)");
+  }
+
+  const wallet = new Wallet(privateKey);
+  let provider: providers.BaseProvider | undefined;
+  if (chain === "local-tableland") {
+    provider = new providers.JsonRpcProvider({
+      url: "http://localhost:8545",
+    });
+  } else if (infura) {
+    provider = new providers.InfuraProvider(network, infura);
+  } else if (etherscan) {
+    provider = new providers.EtherscanProvider(network, etherscan);
+  } else if (alchemy) {
+    provider = new providers.AlchemyProvider(network, alchemy);
+  } else {
+    // This will be significantly rate limited, but we only need to run it once
+    provider = getDefaultProvider(network);
+  }
+  if (!provider) {
+    throw new Error("unable to create ETH API provider");
+  }
+  return wallet.connect(provider);
+}


### PR DESCRIPTION
This PR brings the CLI up to date with the SDK in terms of controller methods. We now support get, set, and lock from the CLI. Additionally, this DRYs out how we extract wallet/signer information on the CLI. It also enables the rpcRelay flag, but doesn't fully support it yet. Lastly, it also updates the underlying usage of the SDK to meet updated create API.