### PR TITLE
Fix ethers rpcJsonProvider and local network

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/cli",
-  "version": "4.0.0-rc1.0",
+  "version": "4.0.0-rc1.1",
   "description": "Tableland command line tools",
   "repository": "https://github.com/tablelandnetwork/js-tableland-cli",
   "publishConfig": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -85,7 +85,9 @@ export function getWalletWithProvider({
 
   const wallet = new Wallet(privateKey);
   let provider: providers.BaseProvider = new providers.JsonRpcProvider(
-    chain === "local-tableland" ? undefined : providerUrl, // Defaults to localhost
+    chain === "local-tableland" && !providerUrl
+      ? "http://127.0.0.1:8545"
+      : providerUrl,
     network.name === "localhost" ? undefined : network.name
   );
   /* c8 ignore start */


### PR DESCRIPTION
The current published release candidate doesn't correctly create a provider when the chain is equal to "local-tableland".