### PR TITLE
Update sdk and local tableland

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@tableland/cli",
-  "version": "4.0.0-pre5.0",
+  "version": "4.0.0-pre6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableland/cli",
-      "version": "4.0.0-pre5.0",
+      "version": "4.0.0-pre6.0",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
-        "@tableland/sdk": "^4.0.0-pre.4",
-        "@tableland/sqlparser": "^1.0.0",
+        "@tableland/sdk": "^4.0.0-pre.6",
+        "@tableland/sqlparser": "^1.0.3",
         "chalk": "^5.1.2",
         "cli-select": "^1.1.2",
         "cli-select-2": "^2.0.0",
@@ -27,7 +27,7 @@
         "tableland": "dist/cli.js"
       },
       "devDependencies": {
-        "@tableland/local": "^1.0.0-pre.1",
+        "@tableland/local": "^1.0.0-pre.2",
         "@types/cosmiconfig": "^6.0.0",
         "@types/inquirer": "^9.0.2",
         "@types/js-yaml": "^4.0.5",
@@ -998,22 +998,22 @@
       "dev": true
     },
     "node_modules/@tableland/evm": {
-      "version": "4.0.0-pre.3",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0-pre.3.tgz",
-      "integrity": "sha512-cHwA+sqwpgErAQUy3Zc4YfYCztXKHPDGw3i/3ynXtFYyZgbtEsfeyCsVVPeCkqifp1vH+1P+rQQTSSGsIH/IKQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0.tgz",
+      "integrity": "sha512-HftJLfg2x2R/f6l6PasrQ73Za071+2T6vmJV+p5PwPtXjlb5Pl+V7rtNWAIZgWE8cQY14lWUyhzw4P/+rrEcGA==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@tableland/local": {
-      "version": "1.0.0-pre.1",
-      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.0.0-pre.1.tgz",
-      "integrity": "sha512-tmFtP7a477EtFoXHFSZik33MzkUTJxHqiyP/uBOzRvHvOHk7FxSLIdldl4waMOyq+9GylqqgfK/LsSb+E/GuzQ==",
+      "version": "1.0.0-pre.2",
+      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.0.0-pre.2.tgz",
+      "integrity": "sha512-jsc04Av9lsCCxBtIhMG639zEd3KGL2mzHm0WPRVsMGt57gKsS5mwGUVk8MQyMfOsYYpQSdDOqsLkpVg345XtVQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@tableland/sdk": "^4.0.0-pre.1",
-        "@tableland/validator": "^0.0.3",
+        "@tableland/sdk": "^4.0.0-pre.5",
+        "@tableland/validator": "^1.0.0",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
         "ethers": "^5.7.2",
@@ -1028,25 +1028,24 @@
       }
     },
     "node_modules/@tableland/sdk": {
-      "version": "4.0.0-pre.4",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.0-pre.4.tgz",
-      "integrity": "sha512-X+ABuuDKQZkPjA1N81pPv1pQmN1J8kSMmv8wk2+aikW7oMNf37IrJ0c9sektlhLP4WEkNK0WFzjJxIVP8/OLrA==",
+      "version": "4.0.0-pre.6",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.0-pre.6.tgz",
+      "integrity": "sha512-Fvud6tiszRI+dNotbCJGgTSWogwUALT+gKC0GgAYf2maSYZvdX9tbI4uSLLBaQz9D12S0aaoAU/OK8656JehIw==",
       "dependencies": {
-        "@tableland/evm": "^4.0.0-pre.3",
-        "@tableland/sqlparser": "^1.0.0",
-        "camelize-ts": "^2.2.0",
+        "@tableland/evm": "^4.0.0",
+        "@tableland/sqlparser": "^1.0.3",
         "ethers": "^5.7.2"
       }
     },
     "node_modules/@tableland/sqlparser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.0.tgz",
-      "integrity": "sha512-RlalXZHXuKKF+kzN1t/oESWXmXyzHHT6SICwZbSanNS2onlivcspoHzp/2CObLGNR50eGKZTzqYhqSFrizOrjw=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.3.tgz",
+      "integrity": "sha512-UlxhHleOfY7bi73rUg0GLgyNcQ28MIOwydOfgiHdfGoqs4vnlDI1W6N0vEDVvpPWy8gPkZlaJI+UFVY0doTcsA=="
     },
     "node_modules/@tableland/validator": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-0.0.3.tgz",
-      "integrity": "sha512-Zzpq96ofuC46uoNj7JwBNxMKoOoxlbVy3rIpFIuyQUagcWlLRumk/JCf4SeWNNEpGu8Y4d+hWsue5uxtKl1Nog==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.0.0.tgz",
+      "integrity": "sha512-ZzryZ+oIE/eOWLRpZrkmws26tJcssKW8RTfAIJ1nsLF6uTM7M4WDSXCVvTvXwnjk4fpPk+F6OiAUG9hSLmupmQ==",
       "dev": true
     },
     "node_modules/@tsconfig/node10": {
@@ -1365,23 +1364,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.1.tgz",
-      "integrity": "sha512-S035ueRrbxRMKvSTv9vJKIWgr86BD8s3RqoRZmsSh/s8HhIs90g6UlK8ZabUSjUZQkhVxt7nmZ63VJ9dcZhtDQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.48.1",
-        "@typescript-eslint/visitor-keys": "5.48.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.48.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.48.2.tgz",
@@ -1464,46 +1446,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.1.tgz",
-      "integrity": "sha512-xHyDLU6MSuEEdIlzrrAerCGS3T7AA/L8Hggd0RCYBi0w3JMvGYxlLlXHeg50JI9Tfg5MrtsfuNxbS/3zF1/ATg==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.1.tgz",
-      "integrity": "sha512-Hut+Osk5FYr+sgFh8J/FHjqX6HFcDzTlWLrFqGoK5kVUN3VBHF/QzZmAsIXCQ8T/W9nQNBTqalxi1P3LSqWnRA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.48.1",
-        "@typescript-eslint/visitor-keys": "5.48.1",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -1596,23 +1538,6 @@
       "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.48.2",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.1.tgz",
-      "integrity": "sha512-Ns0XBwmfuX7ZknznfXozgnydyR8F6ev/KEGePP4i74uL3ArsKbEhJ7raeKr1JSa997DBDwol/4a0Y+At82c9dA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.48.1",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -2070,14 +1995,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/camelize-ts": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/camelize-ts/-/camelize-ts-2.2.0.tgz",
-      "integrity": "sha512-6jMy83qFmNrJIMQXXU6Bi7VVkyl/nBVvoxcVsGRDA6R01pPZpnO/LaIcx6dijJjHbBA2G0uHY4Irk7LeA274NQ==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/chalk": {
@@ -6775,18 +6692,18 @@
       "dev": true
     },
     "@tableland/evm": {
-      "version": "4.0.0-pre.3",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0-pre.3.tgz",
-      "integrity": "sha512-cHwA+sqwpgErAQUy3Zc4YfYCztXKHPDGw3i/3ynXtFYyZgbtEsfeyCsVVPeCkqifp1vH+1P+rQQTSSGsIH/IKQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0.tgz",
+      "integrity": "sha512-HftJLfg2x2R/f6l6PasrQ73Za071+2T6vmJV+p5PwPtXjlb5Pl+V7rtNWAIZgWE8cQY14lWUyhzw4P/+rrEcGA=="
     },
     "@tableland/local": {
-      "version": "1.0.0-pre.1",
-      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.0.0-pre.1.tgz",
-      "integrity": "sha512-tmFtP7a477EtFoXHFSZik33MzkUTJxHqiyP/uBOzRvHvOHk7FxSLIdldl4waMOyq+9GylqqgfK/LsSb+E/GuzQ==",
+      "version": "1.0.0-pre.2",
+      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.0.0-pre.2.tgz",
+      "integrity": "sha512-jsc04Av9lsCCxBtIhMG639zEd3KGL2mzHm0WPRVsMGt57gKsS5mwGUVk8MQyMfOsYYpQSdDOqsLkpVg345XtVQ==",
       "dev": true,
       "requires": {
-        "@tableland/sdk": "^4.0.0-pre.1",
-        "@tableland/validator": "^0.0.3",
+        "@tableland/sdk": "^4.0.0-pre.5",
+        "@tableland/validator": "^1.0.0",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
         "ethers": "^5.7.2",
@@ -6795,25 +6712,24 @@
       }
     },
     "@tableland/sdk": {
-      "version": "4.0.0-pre.4",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.0-pre.4.tgz",
-      "integrity": "sha512-X+ABuuDKQZkPjA1N81pPv1pQmN1J8kSMmv8wk2+aikW7oMNf37IrJ0c9sektlhLP4WEkNK0WFzjJxIVP8/OLrA==",
+      "version": "4.0.0-pre.6",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.0-pre.6.tgz",
+      "integrity": "sha512-Fvud6tiszRI+dNotbCJGgTSWogwUALT+gKC0GgAYf2maSYZvdX9tbI4uSLLBaQz9D12S0aaoAU/OK8656JehIw==",
       "requires": {
-        "@tableland/evm": "^4.0.0-pre.3",
-        "@tableland/sqlparser": "^1.0.0",
-        "camelize-ts": "^2.2.0",
+        "@tableland/evm": "^4.0.0",
+        "@tableland/sqlparser": "^1.0.3",
         "ethers": "^5.7.2"
       }
     },
     "@tableland/sqlparser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.0.tgz",
-      "integrity": "sha512-RlalXZHXuKKF+kzN1t/oESWXmXyzHHT6SICwZbSanNS2onlivcspoHzp/2CObLGNR50eGKZTzqYhqSFrizOrjw=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.3.tgz",
+      "integrity": "sha512-UlxhHleOfY7bi73rUg0GLgyNcQ28MIOwydOfgiHdfGoqs4vnlDI1W6N0vEDVvpPWy8gPkZlaJI+UFVY0doTcsA=="
     },
     "@tableland/validator": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-0.0.3.tgz",
-      "integrity": "sha512-Zzpq96ofuC46uoNj7JwBNxMKoOoxlbVy3rIpFIuyQUagcWlLRumk/JCf4SeWNNEpGu8Y4d+hWsue5uxtKl1Nog==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.0.0.tgz",
+      "integrity": "sha512-ZzryZ+oIE/eOWLRpZrkmws26tJcssKW8RTfAIJ1nsLF6uTM7M4WDSXCVvTvXwnjk4fpPk+F6OiAUG9hSLmupmQ==",
       "dev": true
     },
     "@tsconfig/node10": {
@@ -7050,16 +6966,6 @@
         }
       }
     },
-    "@typescript-eslint/scope-manager": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.1.tgz",
-      "integrity": "sha512-S035ueRrbxRMKvSTv9vJKIWgr86BD8s3RqoRZmsSh/s8HhIs90g6UlK8ZabUSjUZQkhVxt7nmZ63VJ9dcZhtDQ==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.48.1",
-        "@typescript-eslint/visitor-keys": "5.48.1"
-      }
-    },
     "@typescript-eslint/type-utils": {
       "version": "5.48.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.48.2.tgz",
@@ -7103,27 +7009,6 @@
             "eslint-visitor-keys": "^3.3.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.1.tgz",
-      "integrity": "sha512-xHyDLU6MSuEEdIlzrrAerCGS3T7AA/L8Hggd0RCYBi0w3JMvGYxlLlXHeg50JI9Tfg5MrtsfuNxbS/3zF1/ATg==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.1.tgz",
-      "integrity": "sha512-Hut+Osk5FYr+sgFh8J/FHjqX6HFcDzTlWLrFqGoK5kVUN3VBHF/QzZmAsIXCQ8T/W9nQNBTqalxi1P3LSqWnRA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.48.1",
-        "@typescript-eslint/visitor-keys": "5.48.1",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/utils": {
@@ -7183,16 +7068,6 @@
             "eslint-visitor-keys": "^3.3.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.1.tgz",
-      "integrity": "sha512-Ns0XBwmfuX7ZknznfXozgnydyR8F6ev/KEGePP4i74uL3ArsKbEhJ7raeKr1JSa997DBDwol/4a0Y+At82c9dA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.48.1",
-        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "acorn": {
@@ -7518,11 +7393,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true
-    },
-    "camelize-ts": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/camelize-ts/-/camelize-ts-2.2.0.tgz",
-      "integrity": "sha512-6jMy83qFmNrJIMQXXU6Bi7VVkyl/nBVvoxcVsGRDA6R01pPZpnO/LaIcx6dijJjHbBA2G0uHY4Irk7LeA274NQ=="
     },
     "chalk": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "license": "MIT AND Apache-2.0",
   "devDependencies": {
-    "@tableland/local": "^1.0.0-pre.1",
+    "@tableland/local": "^1.0.0-pre.2",
     "@types/cosmiconfig": "^6.0.0",
     "@types/inquirer": "^9.0.2",
     "@types/js-yaml": "^4.0.5",
@@ -61,8 +61,8 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "@tableland/sdk": "^4.0.0-pre.4",
-    "@tableland/sqlparser": "^1.0.0",
+    "@tableland/sdk": "^4.0.0-pre.6",
+    "@tableland/sqlparser": "^1.0.3",
     "chalk": "^5.1.2",
     "cli-select": "^1.1.2",
     "cli-select-2": "^2.0.0",

--- a/src/commands/controller.ts
+++ b/src/commands/controller.ts
@@ -1,6 +1,6 @@
 import type yargs from "yargs";
 import type { Arguments, CommandBuilder } from "yargs";
-import { ChainName, Registry } from "@tableland/sdk";
+import { helpers, Registry } from "@tableland/sdk";
 import { getWalletWithProvider, getLink } from "../utils.js";
 export type Options = {
   // Local
@@ -9,7 +9,7 @@ export type Options = {
 
   // Global
   privateKey: string;
-  chain: ChainName;
+  chain: helpers.ChainName;
   providerUrl: string | undefined;
   baseUrl: string | undefined;
 };

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,6 +1,6 @@
 import type yargs from "yargs";
 import type { Arguments, CommandBuilder } from "yargs";
-import { Database, ChainName } from "@tableland/sdk";
+import { Database, helpers } from "@tableland/sdk";
 import { getWalletWithProvider, getLink } from "../utils.js";
 import { createInterface } from "readline";
 import { promises } from "fs";
@@ -13,7 +13,7 @@ export type Options = {
 
   // Global
   privateKey: string;
-  chain: ChainName;
+  chain: helpers.ChainName;
   providerUrl: string | undefined;
   baseUrl: string | undefined;
 };

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,6 +1,6 @@
 import type yargs from "yargs";
 import type { Arguments, CommandBuilder } from "yargs";
-import { getChainInfo, Validator } from "@tableland/sdk";
+import { helpers, Validator } from "@tableland/sdk";
 
 export type Options = {
   // Local
@@ -30,7 +30,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   }
 
   const chain = parseInt(chainId);
-  const network = getChainInfo(chain);
+  const network = helpers.getChainInfo(chain);
 
   if (!network) {
     console.error("unsupported chain (see `chains` command for details)");

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -15,7 +15,7 @@ export type Options = {
 
 const defaults = {
   chain: "maticmum",
-  rpcRelay: false,
+  // rpcRelay: false,
 };
 
 const moduleName = "tableland";

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,7 +1,7 @@
 import type yargs from "yargs";
 import type { Arguments, CommandBuilder } from "yargs";
 import { Wallet } from "ethers";
-import { ChainName, Registry } from "@tableland/sdk";
+import { helpers, Registry } from "@tableland/sdk";
 import { getChains, getWalletWithProvider } from "../utils.js";
 
 export type Options = {
@@ -10,7 +10,7 @@ export type Options = {
 
   // Global
   privateKey: string;
-  chain: ChainName;
+  chain: helpers.ChainName;
   providerUrl: string;
 };
 

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -1,5 +1,5 @@
 import type { Arguments, CommandBuilder } from "yargs";
-import { Database, ChainName } from "@tableland/sdk";
+import { Database, helpers } from "@tableland/sdk";
 import yargs from "yargs";
 import { promises } from "fs";
 import { createInterface } from "readline";
@@ -12,7 +12,7 @@ export type Options = {
   file?: string;
 
   // Global
-  chain: ChainName;
+  chain: helpers.ChainName;
   baseUrl: string | undefined;
 };
 

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -1,6 +1,6 @@
 import type yargs from "yargs";
 import type { Arguments, CommandBuilder } from "yargs";
-import { ChainName, Validator, getChainId } from "@tableland/sdk";
+import { helpers, Validator } from "@tableland/sdk";
 import { getChains } from "../utils.js";
 
 export type Options = {
@@ -9,7 +9,7 @@ export type Options = {
 
   // Global
   privateKey: string;
-  chain: ChainName;
+  chain: helpers.ChainName;
   baseUrl: string | undefined;
 };
 
@@ -35,7 +35,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   try {
     const v = baseUrl ? new Validator({ baseUrl }) : Validator.forChain(chain);
     const res = await v.receiptByTransactionHash({
-      chainId: getChainId(chain),
+      chainId: helpers.getChainId(chain),
       transactionHash: hash,
     });
     console.log(res);

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -1,6 +1,6 @@
 import type yargs from "yargs";
 import type { Arguments, CommandBuilder } from "yargs";
-import { getChainInfo, Validator } from "@tableland/sdk";
+import { helpers, Validator } from "@tableland/sdk";
 
 export type Options = {
   // Local
@@ -30,7 +30,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
 
   const tableId = parts.pop() as string;
   const chainId = parseInt(parts.pop()!);
-  const network = getChainInfo(chainId);
+  const network = helpers.getChainInfo(chainId);
 
   if (!network) {
     console.error("unsupported chain (see `chains` command for details)");

--- a/src/commands/shell.ts
+++ b/src/commands/shell.ts
@@ -1,6 +1,6 @@
 import yargs, { Arguments, CommandBuilder } from "yargs";
 import cliSelect from "cli-select";
-import { ChainName, Database, Config } from "@tableland/sdk";
+import { helpers, Database } from "@tableland/sdk";
 import chalk from "chalk";
 import { createInterface } from "readline";
 import { getChains, getWalletWithProvider } from "../utils.js";
@@ -12,7 +12,7 @@ export type Options = {
   format: "pretty" | "table" | "objects";
 
   // Global
-  chain: ChainName;
+  chain: helpers.ChainName;
   privateKey: string;
   providerUrl: string | undefined;
   verbose: boolean;
@@ -189,7 +189,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
       chain,
       providerUrl,
     });
-    const options: Config = {
+    const options: helpers.Config = {
       signer,
       baseUrl,
     };

--- a/src/commands/write.ts
+++ b/src/commands/write.ts
@@ -1,6 +1,6 @@
 import type yargs from "yargs";
 import type { Arguments, CommandBuilder } from "yargs";
-import { ChainName, Database } from "@tableland/sdk";
+import { helpers, Database } from "@tableland/sdk";
 import { getWalletWithProvider, getLink } from "../utils.js";
 import { promises } from "fs";
 import { createInterface } from "readline";
@@ -12,7 +12,7 @@ export type Options = {
 
   // Global
   privateKey: string;
-  chain: ChainName;
+  chain: helpers.ChainName;
   providerUrl: string | undefined;
   baseUrl: string | undefined;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,23 +1,23 @@
 import { Wallet, providers, getDefaultProvider } from "ethers";
-import { ChainName, getChainInfo, supportedChains } from "@tableland/sdk";
+import { helpers } from "@tableland/sdk";
 
 export const getChains = () =>
   Object.fromEntries(
-    Object.entries(supportedChains).filter(
+    Object.entries(helpers.supportedChains).filter(
       ([name]) => !name.includes("staging")
     )
   );
 
 export interface Options {
   privateKey: string;
-  chain: ChainName;
+  chain: helpers.ChainName;
   providerUrl: string | undefined;
 }
 
 export const wait = (timeout: number) =>
   new Promise((resolve) => setTimeout(resolve, timeout));
 
-export function getLink(chain: ChainName, hash: string): string {
+export function getLink(chain: helpers.ChainName, hash: string): string {
   /* c8 ignore start */
   if (chain.includes("ethereum")) {
     if (chain.includes("goerli")) {
@@ -52,7 +52,7 @@ export function getWalletWithProvider({
   if (privateKey == null) {
     throw new Error("missing required flag (`-k` or `--privateKey`)");
   }
-  const network: any = getChainInfo(chain);
+  const network: any = helpers.getChainInfo(chain);
   if (network == null) {
     throw new Error("unsupported chain (see `chains` command for details)");
   }

--- a/test/info.test.ts
+++ b/test/info.test.ts
@@ -25,6 +25,7 @@ describe("commands/info", function () {
   });
 
   test("throws with invalid chain", async function () {
+    // TODO: Figure out how to test this error.
     const consoleError = spy(console, "error");
     await yargs(["info", "valid_9999_0"]).command(mod).parse();
     assert.calledWith(

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -22,6 +22,7 @@ describe("commands/schema", function () {
   });
 
   test("throws with invalid chain", async function () {
+    // TODO: Figure out how to test this error.
     const consoleError = spy(console, "error");
     await yargs(["schema", "valid_9999_0"]).command(mod).parse();
     assert.calledWith(


### PR DESCRIPTION
Mostly fixes with `helpers`. There are two tests failing and i'm not sure how to correct them. I think the problem is that previously the error related to an invalid chain id was raised with `console.error()` within the CLI code and the tests were able to test that correctly. But now the invalid chain id error is thrown from within the SDK code, and the test doesn't handle that correctly. 