### PR TITLE
fix #212 remove default chain param value

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,7 +60,6 @@ const _argv = yargs(hideBin(process.argv))
     alias: "c",
     type: "string",
     description: "The EVM chain to target",
-    default: "maticmum",
   })
   .option("enableEnsExperiment", {
     type: "boolean",

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -30,10 +30,10 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
       return;
     }
 
-    const { ens, validator } = await setupCommand(
-      { ...argv, chain: parseInt(chainId) as any },
-      { readOnly: true }
-    );
+    const { ens, validator } = await setupCommand({
+      ...argv,
+      chain: parseInt(chainId) as any,
+    });
 
     if (argv.enableEnsExperiment && ens) {
       name = await ens.resolveTable(name);

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -20,9 +20,12 @@ export const builder: CommandBuilder<{}, Options> = (yargs) => {
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   try {
-    const { privateKey } = argv;
+    const { chain, privateKey } = argv;
     let { address } = argv;
-
+    if (!chain) {
+      console.error("missing required flag (`-c` or `--chain`)");
+      return;
+    }
     if (!address) {
       if (privateKey) {
         address = new Wallet(privateKey).address;

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -39,7 +39,6 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   const { format, file } = argv;
 
   try {
-    const { database, ens } = await setupCommand(argv, { readOnly: true });
     if (file != null) {
       statement = await promises.readFile(file, { encoding: "utf-8" });
     } else if (statement == null) {
@@ -54,7 +53,11 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
       );
       return;
     }
-    const db = database;
+
+    const { database: db, ens } = await setupCommand(argv, {
+      readOnly: true,
+      statement,
+    });
 
     if (argv.enableEnsExperiment && ens) {
       statement = await ens.resolve(statement);

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -54,10 +54,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
       return;
     }
 
-    const { database: db, ens } = await setupCommand(argv, {
-      readOnly: true,
-      statement,
-    });
+    const { database: db, ens } = await setupCommand(argv);
 
     if (argv.enableEnsExperiment && ens) {
       statement = await ens.resolve(statement);

--- a/src/commands/receipt.ts
+++ b/src/commands/receipt.ts
@@ -21,6 +21,10 @@ export const builder: CommandBuilder<{}, Options> = (yargs) =>
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   try {
     const { hash, chain } = argv;
+    if (!chain) {
+      console.error("missing required flag (`-c` or `--chain`)");
+      return;
+    }
     const { validator } = await setupCommand(argv);
     const res = await validator.receiptByTransactionHash({
       chainId: helpers.getChainId(chain),

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -30,10 +30,10 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
       return;
     }
 
-    const { validator } = await setupCommand(
-      { ...argv, chain: parseInt(chainId) as any },
-      { readOnly: true }
-    );
+    const { validator } = await setupCommand({
+      ...argv,
+      chain: parseInt(chainId) as any,
+    });
 
     const res = await validator.getTableById({
       tableId,

--- a/src/commands/shell.ts
+++ b/src/commands/shell.ts
@@ -160,6 +160,11 @@ export const builder: CommandBuilder<{}, Options> = (yargs) =>
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   try {
+    const { chain } = argv;
+    if (!chain) {
+      console.error("missing required flag (`-c` or `--chain`)");
+      return;
+    }
     const connections = await setupCommand(argv);
     const { signer, network } = connections;
     console.log("Welcome to Tableland");

--- a/src/lib/commandSetup.ts
+++ b/src/lib/commandSetup.ts
@@ -121,7 +121,7 @@ export class Connections {
       baseUrl,
     });
 
-    if (baseUrl || !chain) {
+    if (baseUrl) {
       this._validator = new Validator({ baseUrl });
     } else if (chain) {
       this._validator = Validator.forChain(chain);

--- a/src/lib/commandSetup.ts
+++ b/src/lib/commandSetup.ts
@@ -5,11 +5,6 @@ import { GlobalOptions } from "../cli.js";
 import { getWalletWithProvider } from "../utils.js";
 import EnsResolver from "./EnsResolver.js";
 
-export type ConnectionsOptions = {
-  readOnly: boolean;
-  statement?: string;
-};
-
 export class Connections {
   _database: Database | undefined;
   _validator: Validator | undefined;
@@ -73,86 +68,70 @@ export class Connections {
     return this._network;
   }
 
-  constructor(
-    argv: GlobalOptions,
-    options: { readOnly: boolean } = { readOnly: false }
-  ) {
-    this._ready = this.prepare(argv, options).then(() => {
+  constructor(argv: GlobalOptions) {
+    this._ready = this.prepare(argv).then(() => {
       this._readyResolved = true;
     });
   }
 
-  async prepare(
-    argv: GlobalOptions,
-    options: ConnectionsOptions = { readOnly: false }
-  ) {
+  // Once a command is issued we want to collect the args and options and
+  // "prepare" all of the underlying interfaces, e.g. validator, signer, database, etc...
+  // The strategy we are employing here boils down to, "setup everything we can with what we are given"
+  // Then the command handler will have everything it needs as long as it is requiring the correct
+  // args.
+  async prepare(argv: GlobalOptions) {
     const {
       privateKey,
       providerUrl,
+      chain,
       baseUrl,
       enableEnsExperiment,
       ensProviderUrl,
     } = argv;
-    let { chain } = argv;
-    const { readOnly, statement } = options;
-    let signer: Signer | undefined;
 
-    // If the command is read only and there isn't an explicit chain, we will
-    // try to get the chain from the statement by looking at the first table.
-    if (options.readOnly && !chain && statement) {
-      try {
-        const { tables } = await sqlparser.normalize(statement); // eslint-disable-line no-undef
-        const { chainId } = await sqlparser.validateTableName(tables[0]); // eslint-disable-line no-undef
-        chain = helpers.getChainInfo(chainId).chainName;
-      } catch (err) {
-        throw new Error(`a chain is required for read statement: ${statement}`);
-      }
-    }
-
-    if (!options.readOnly) {
-      signer = await getWalletWithProvider({
+    if (privateKey && chain) {
+      this._signer = await getWalletWithProvider({
         privateKey,
+        // providerUrl is optional, and this might be undefined
         providerUrl,
         chain,
       });
-      this._signer = signer;
     }
 
     if (enableEnsExperiment && ensProviderUrl) {
       this._ens = new EnsResolver({
         ensProviderUrl,
-        signer,
+        signer: this._signer,
       });
     }
-    try {
-      this._network = helpers.getChainInfo(chain);
-    } catch (e) {
-      console.error("unsupported chain (see `chains` command for details)");
+
+    if (chain) {
+      try {
+        this._network = helpers.getChainInfo(chain);
+      } catch (e) {
+        console.error("unsupported chain (see `chains` command for details)");
+      }
     }
 
-    if (signer) this._registry = new Registry({ signer });
+    if (this._signer) this._registry = new Registry({ signer: this._signer });
 
-    this._database =
-      readOnly && !baseUrl
-        ? Database.readOnly(chain)
-        : new Database({
-            signer,
-            baseUrl,
-          });
+    this._database = new Database({
+      // both of these props might be undefined
+      signer: this._signer,
+      baseUrl,
+    });
 
-    this._validator =
-      baseUrl || !chain
-        ? new Validator({ baseUrl })
-        : Validator.forChain(chain);
+    if (baseUrl || !chain) {
+      this._validator = new Validator({ baseUrl });
+    } else if (chain) {
+      this._validator = Validator.forChain(chain);
+    }
   }
 }
 
-export async function setupCommand(
-  argv: GlobalOptions,
-  options?: ConnectionsOptions
-) {
+export async function setupCommand(argv: GlobalOptions) {
   await init();
-  const connections = new Connections(argv, options);
+  const connections = new Connections(argv);
   await connections.ready();
   return connections;
 }

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -27,6 +27,24 @@ describe("commands/create", function () {
     );
   });
 
+  test("throws if chain not provided", async function () {
+    const [account] = getAccounts();
+    const privateKey = account.privateKey.slice(2);
+    const consoleError = spy(console, "error");
+    await yargs([
+      "create",
+      "(id int primary key, desc text)",
+      "--privateKey",
+      privateKey,
+    ])
+      .command(mod)
+      .parse();
+    assert.calledWith(
+      consoleError,
+      "missing required flag (`-c` or `--chain`)"
+    );
+  });
+
   test("throws with invalid chain", async function () {
     const [account] = getAccounts();
     const privateKey = account.privateKey.slice(2);
@@ -36,6 +54,8 @@ describe("commands/create", function () {
       "(id int primary key, desc text)",
       "--privateKey",
       privateKey,
+      "--chain",
+      "foozbaaz",
     ])
       .command(mod)
       .parse();

--- a/test/list.test.ts
+++ b/test/list.test.ts
@@ -13,9 +13,9 @@ describe("commands/list", function () {
     restore();
   });
 
-  test("throws without privateKey", async function () {
+  test("throws without privateKey or address", async function () {
     const consoleError = spy(console, "error");
-    await yargs(["list"]).command(mod).parse();
+    await yargs(["list", "--chain", "maticmum"]).command(mod).parse();
     assert.calledWith(
       consoleError,
       "must supply `--privateKey` or `address` positional"
@@ -27,6 +27,19 @@ describe("commands/list", function () {
     const privateKey = account.privateKey.slice(2);
     const consoleError = spy(console, "error");
     await yargs(["list", "--privateKey", privateKey]).command(mod).parse();
+    assert.calledWith(
+      consoleError,
+      "missing required flag (`-c` or `--chain`)"
+    );
+  });
+
+  test("List throws with invalid chain", async function () {
+    const [account] = getAccounts();
+    const privateKey = account.privateKey.slice(2);
+    const consoleError = spy(console, "error");
+    await yargs(["list", "--privateKey", privateKey, "--chain", "foozbazz"])
+      .command(mod)
+      .parse();
     assert.calledWith(
       consoleError,
       "unsupported chain (see `chains` command for details)"

--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -16,19 +16,29 @@ describe("commands/read", function () {
     restore();
   });
 
-  test("throws with invalid chain", async function () {
+  test("throws with invalid table name", async function () {
     const consoleError = spy(console, "error");
-    const statement = "select * from something;";
-    await yargs(["read", statement]).command(mod).parse();
+    const tableName = "something";
+    const statement = `select * from ${tableName};`;
+    await yargs(["read", statement, "--baseUrl", "http://127.0.0.1:8080"])
+      .command(mod)
+      .parse();
     assert.calledWith(
       consoleError,
-      `a chain is required for read statement: ${statement}`
+      `error validating name: table name has wrong format: ${tableName}`
     );
+  });
+
+  test("throws with missing baseUrl", async function () {
+    const consoleError = spy(console, "error");
+    const statement = "select * from something_31337_1;";
+    await yargs(["read", statement]).command(mod).parse();
+    assert.calledWith(consoleError, "missing baseUrl information");
   });
 
   test("throws with invalid statement", async function () {
     const consoleError = spy(console, "error");
-    await yargs(["read", "invalid;", "--chain", "local-tableland"])
+    await yargs(["read", "invalid;", "--baseUrl", "http://127.0.0.1:8080"])
       .command(mod)
       .parse();
     assert.calledWith(
@@ -39,7 +49,13 @@ describe("commands/read", function () {
 
   test("throws with missing file", async function () {
     const consoleError = spy(console, "error");
-    await yargs(["read", "--file", "missing.sql", "--chain", "local-tableland"])
+    await yargs([
+      "read",
+      "--file",
+      "missing.sql",
+      "--baseUrl",
+      "http://127.0.0.1:8080",
+    ])
       .command(mod)
       .parse();
     assert.calledWith(
@@ -56,7 +72,9 @@ describe("commands/read", function () {
     setTimeout(() => {
       stdin.send("\n").end();
     }, 100);
-    await yargs(["read", "--chain", "local-tableland"]).command(mod).parse();
+    await yargs(["read", "--baseUrl", "http://127.0.0.1:8080"])
+      .command(mod)
+      .parse();
     assert.calledWith(
       consoleError,
       "missing input value (`statement`, `file`, or piped input from stdin required)"
@@ -68,8 +86,8 @@ describe("commands/read", function () {
     await yargs([
       "read",
       "select * from healthbot_31337_1",
-      "--chain",
-      "local-tableland",
+      "--baseUrl",
+      "http://127.0.0.1:8080",
     ])
       .command(mod)
       .parse();
@@ -87,8 +105,8 @@ describe("commands/read", function () {
     await yargs([
       "read",
       "select * from healthbot_31337_1;",
-      "--chain",
-      "local-tableland",
+      "--baseUrl",
+      "http://127.0.0.1:8080",
       "--format",
       "objects",
     ])
@@ -108,8 +126,8 @@ describe("commands/read", function () {
     const path = await temporaryWrite("select * from healthbot_31337_1;\n");
     await yargs([
       "read",
-      "--chain",
-      "local-tableland",
+      "--baseUrl",
+      "http://127.0.0.1:8080",
       "--file",
       path,
       "--format",
@@ -134,8 +152,8 @@ describe("commands/read", function () {
     }, 100);
     await yargs([
       "read",
-      "--chain",
-      "local-tableland",
+      "--baseUrl",
+      "http://127.0.0.1:8080",
       "--format",
       "objects",
       "--providerUrl",
@@ -157,8 +175,6 @@ describe("commands/read", function () {
     await yargs([
       "read",
       "select * from healthbot_31337_1;",
-      "--chain",
-      "local-tableland",
       "--format",
       "pretty",
       "--baseUrl",
@@ -178,8 +194,8 @@ describe("commands/read", function () {
     await yargs([
       "read",
       "select * from healthbot_31337_1;",
-      "--chain",
-      "local-tableland",
+      "--baseUrl",
+      "http://127.0.0.1:8080",
       "--format",
       "pretty",
     ])

--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -18,10 +18,11 @@ describe("commands/read", function () {
 
   test("throws with invalid chain", async function () {
     const consoleError = spy(console, "error");
-    await yargs(["read", "select * from something;"]).command(mod).parse();
+    const statement = "select * from something;";
+    await yargs(["read", statement]).command(mod).parse();
     assert.calledWith(
       consoleError,
-      "unsupported chain (see `chains` command for details)"
+      `a chain is required for read statement: ${statement}`
     );
   });
 

--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -29,13 +29,6 @@ describe("commands/read", function () {
     );
   });
 
-  test("throws with missing baseUrl", async function () {
-    const consoleError = spy(console, "error");
-    const statement = "select * from something_31337_1;";
-    await yargs(["read", statement]).command(mod).parse();
-    assert.calledWith(consoleError, "missing baseUrl information");
-  });
-
   test("throws with invalid statement", async function () {
     const consoleError = spy(console, "error");
     await yargs(["read", "invalid;", "--baseUrl", "http://127.0.0.1:8080"])
@@ -83,12 +76,7 @@ describe("commands/read", function () {
 
   test("Read passes with local-tableland (defaults to table format)", async function () {
     const consoleDir = spy(console, "dir");
-    await yargs([
-      "read",
-      "select * from healthbot_31337_1",
-      "--baseUrl",
-      "http://127.0.0.1:8080",
-    ])
+    await yargs(["read", "select * from healthbot_31337_1"])
       .command(mod)
       .parse();
     assert.calledWith(
@@ -105,8 +93,6 @@ describe("commands/read", function () {
     await yargs([
       "read",
       "select * from healthbot_31337_1;",
-      "--baseUrl",
-      "http://127.0.0.1:8080",
       "--format",
       "objects",
     ])
@@ -124,15 +110,7 @@ describe("commands/read", function () {
   test("passes when provided input from file", async function () {
     const consoleDir = spy(console, "dir");
     const path = await temporaryWrite("select * from healthbot_31337_1;\n");
-    await yargs([
-      "read",
-      "--baseUrl",
-      "http://127.0.0.1:8080",
-      "--file",
-      path,
-      "--format",
-      "objects",
-    ])
+    await yargs(["read", "--file", path, "--format", "objects"])
       .command(mod)
       .parse();
     assert.calledWith(
@@ -152,8 +130,6 @@ describe("commands/read", function () {
     }, 100);
     await yargs([
       "read",
-      "--baseUrl",
-      "http://127.0.0.1:8080",
       "--format",
       "objects",
       "--providerUrl",
@@ -194,8 +170,6 @@ describe("commands/read", function () {
     await yargs([
       "read",
       "select * from healthbot_31337_1;",
-      "--baseUrl",
-      "http://127.0.0.1:8080",
       "--format",
       "pretty",
     ])

--- a/test/receipt.test.ts
+++ b/test/receipt.test.ts
@@ -26,6 +26,26 @@ describe("commands/receipt", function () {
       .parse();
     assert.calledWith(
       consoleError,
+      "missing required flag (`-c` or `--chain`)"
+    );
+  });
+
+  test("Receipt throws with invalid chain", async function () {
+    const [account] = getAccounts();
+    const privateKey = account.privateKey.slice(2);
+    const consoleError = spy(console, "error");
+    await yargs([
+      "receipt",
+      "--privateKey",
+      privateKey,
+      "--chain",
+      "foozbazz",
+      "ignored",
+    ])
+      .command(mod)
+      .parse();
+    assert.calledWith(
+      consoleError,
       "unsupported chain (see `chains` command for details)"
     );
   });

--- a/test/shell.test.ts
+++ b/test/shell.test.ts
@@ -49,11 +49,24 @@ describe("commands/shell", function () {
     );
   });
 
-  test("Shell throws without network", async function () {
+  test("Shell throws without chain", async function () {
     const [account] = getAccounts();
     const privateKey = account.privateKey.slice(2);
     const consoleError = spy(console, "error");
     await yargs(["shell", "--privateKey", privateKey]).command(mod).parse();
+    assert.calledWith(
+      consoleError,
+      "missing required flag (`-c` or `--chain`)"
+    );
+  });
+
+  test("Shell throws with invalid chain", async function () {
+    const [account] = getAccounts();
+    const privateKey = account.privateKey.slice(2);
+    const consoleError = spy(console, "error");
+    await yargs(["shell", "--privateKey", privateKey, "--chain", "foozbazz"])
+      .command(mod)
+      .parse();
     assert.calledWith(
       consoleError,
       "unsupported chain (see `chains` command for details)"

--- a/test/write.test.ts
+++ b/test/write.test.ts
@@ -27,6 +27,24 @@ describe("commands/write", function () {
     );
   });
 
+  test("throws missing chain", async function () {
+    const [account] = getAccounts();
+    const privateKey = account.privateKey.slice(2);
+    const consoleError = spy(console, "error");
+    await yargs([
+      "write",
+      "insert into fake_31337_1 values (1, 2, 3);",
+      "--privateKey",
+      privateKey,
+    ])
+      .command(mod)
+      .parse();
+    assert.calledWith(
+      consoleError,
+      "missing required flag (`-c` or `--chain`)"
+    );
+  });
+
   test("throws with invalid chain", async function () {
     const [account] = getAccounts();
     const privateKey = account.privateKey.slice(2);
@@ -36,6 +54,8 @@ describe("commands/write", function () {
       "insert into fake_31337_1 values (1, 2, 3);",
       "--privateKey",
       privateKey,
+      "--chain",
+      "foozbazz",
     ])
       .command(mod)
       .parse();


### PR DESCRIPTION
## Context

Fix for #212 
The read command was using the SDK's `Database.readOnly` function, which requires a chain.  Using the default Database constructor removes this requirement.
related: https://github.com/tablelandnetwork/js-tableland/issues/375

## Details

Because we had a default value for the `chain` param, read commands that run against the mainnets would fail with a "no such table" message unless the caller specifies a mainnet chain.  This is somewhat confusing, and not really necessary because the chain can (almost always?) be derived from the query statement.

Some notes on the changes here:
 - removes the default value for the chain param.
 - because we are changing the default behaviour I believe we will need to bump a major version for this change.