### PR TITLE
[JSTC-8] Implement table transfer command in js-tableland-cli

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -10,6 +10,7 @@ import * as schema from "./schema.js";
 import * as write from "./write.js";
 import * as shell from "./shell.js";
 import * as namespace from "./namespace.js";
+import * as transfer from "./transfer.js";
 
 export const commands = [
   chains,
@@ -24,4 +25,5 @@ export const commands = [
   write,
   shell,
   namespace,
+  transfer,
 ];

--- a/src/commands/transfer.ts
+++ b/src/commands/transfer.ts
@@ -25,7 +25,7 @@ export const builder: CommandBuilder<{}, Options> = (yargs) =>
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   try {
     const { name, receiver } = argv;
-    const [chainId] = name.split("_").reverse()[1];
+    const [tableId, chainId] = name.split("_").reverse();
 
     const parts = name.split("_");
 

--- a/src/commands/transfer.ts
+++ b/src/commands/transfer.ts
@@ -1,0 +1,53 @@
+import type yargs from "yargs";
+import type { Arguments, CommandBuilder } from "yargs";
+import { GlobalOptions } from "../cli.js";
+import { setupCommand } from "../lib/commandSetup.js";
+
+export interface Options extends GlobalOptions {
+  name: string;
+  receiver: string;
+}
+
+export const command = "transfer <name> <receiver>";
+export const desc = "Transfer a table to another address";
+
+export const builder: CommandBuilder<{}, Options> = (yargs) =>
+  yargs
+    .positional("name", {
+      type: "string",
+      description: "The target table name",
+    })
+    .positional("receiver", {
+      type: "string",
+      description: "The address to transfer the table to",
+    }) as yargs.Argv<Options>;
+
+export const handler = async (argv: Arguments<Options>): Promise<void> => {
+  try {
+    const { name, receiver } = argv;
+    const [chainId] = name.split("_").reverse()[1];
+
+    const parts = name.split("_");
+
+    if (parts.length < 3 && !argv.enableEnsExperiment) {
+      console.error(
+        "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
+      );
+      return;
+    }
+
+    const { registry } = await setupCommand({
+      ...argv,
+      chain: parseInt(chainId) as any,
+    });
+
+    const res = await registry.safeTransferFrom({
+      tableName: name,
+      to: receiver,
+    });
+    console.log(JSON.stringify(res));
+    /* c8 ignore next 3 */
+  } catch (err: any) {
+    console.error(err.message);
+  }
+};

--- a/src/commands/transfer.ts
+++ b/src/commands/transfer.ts
@@ -24,7 +24,7 @@ export const builder: CommandBuilder<{}, Options> = (yargs) =>
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   try {
-    const { name, receiver } = argv;
+    const { name, receiver, chain } = argv;
     const parts = name.split("_").reverse();
     const chainId = parts[1];
 
@@ -37,7 +37,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
 
     const { registry } = await setupCommand({
       ...argv,
-      chain: parseInt(chainId) as any,
+      chain: chain || (parseInt(chainId) as any),
     });
 
     const res = await registry.safeTransferFrom({

--- a/src/commands/transfer.ts
+++ b/src/commands/transfer.ts
@@ -25,9 +25,8 @@ export const builder: CommandBuilder<{}, Options> = (yargs) =>
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   try {
     const { name, receiver } = argv;
-    const [tableId, chainId] = name.split("_").reverse();
-
-    const parts = name.split("_");
+    const parts = name.split("_").reverse();
+    const chainId = parts[1];
 
     if (parts.length < 3 && !argv.enableEnsExperiment) {
       console.error(

--- a/src/lib/commandSetup.ts
+++ b/src/lib/commandSetup.ts
@@ -33,13 +33,16 @@ export class Connections {
 
   get registry(): Registry {
     this.readyCheck();
-    if (!this._registry) throw new Error("No registry");
+    if (!this._registry)
+      throw new Error(
+        "No registry. This may be because you did not specify a private key with which to interact with the registry."
+      );
     return this._registry;
   }
 
   get validator(): Validator {
     this.readyCheck();
-    if (!this._validator) throw new Error("No registry");
+    if (!this._validator) throw new Error("No validator");
     return this._validator;
   }
 

--- a/src/lib/commandSetup.ts
+++ b/src/lib/commandSetup.ts
@@ -42,7 +42,8 @@ export class Connections {
 
   get validator(): Validator {
     this.readyCheck();
-    if (!this._validator) throw new Error("No validator");
+    if (!this._validator)
+      throw new Error("No validator. Set a chain or a baseURL.");
     return this._validator;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,7 +70,7 @@ export async function getWalletWithProvider({
 
   // Second we will check if the "local-tableland" chain is being used,
   // because the default provider won't work with this chain.
-  if (!provider && chain === "local-tableland") {
+  if (!provider && network.chainName === "local-tableland") {
     provider = new providers.JsonRpcProvider("http://127.0.0.1:8545");
   }
 

--- a/test/transfer.test.ts
+++ b/test/transfer.test.ts
@@ -37,7 +37,7 @@ describe("commands/transfer", function () {
   });
 
   test("throws with invalid chain", async function () {
-    const [, account] = getAccounts();
+    const account = accounts[1];
     const privateKey = account.privateKey.slice(2);
     const consoleError = spy(console, "error");
     await yargs([
@@ -58,7 +58,7 @@ describe("commands/transfer", function () {
   });
 
   test("throws with invalid table name", async function () {
-    const [, account] = getAccounts();
+    const account = accounts[1];
     const privateKey = account.privateKey.slice(2);
     const consoleError = spy(console, "error");
     await yargs(["transfer", "fooz", "blah", "-k", privateKey])
@@ -66,12 +66,12 @@ describe("commands/transfer", function () {
       .parse();
     assert.calledWith(
       consoleError,
-      "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
+      "error validating name: table name has wrong format: fooz"
     );
   });
 
   test("throws with invalid receiver address", async function () {
-    const [, account] = getAccounts();
+    const account = accounts[1];
     const privateKey = account.privateKey.slice(2);
     const consoleError = spy(console, "error");
     await yargs([
@@ -93,7 +93,7 @@ describe("commands/transfer", function () {
 
   // Does transfering table have knock-on effects on other tables?
   test("Write passes with local-tableland", async function () {
-    const [, account1, account2] = getAccounts();
+    const [, account1, account2] = accounts;
     const account2Address = account2.address;
     const consoleLog = spy(console, "log");
     const privateKey = account1.privateKey.slice(2);

--- a/test/transfer.test.ts
+++ b/test/transfer.test.ts
@@ -28,7 +28,24 @@ describe("commands/transfer", function () {
     );
   });
 
-  test("throws with invalid chain", async function () {});
+  test("throws with invalid chain", async function () {
+    const [account] = getAccounts();
+    const privateKey = account.privateKey.slice(2);
+    const consoleError = spy(console, "error");
+    await yargs([
+      "transfer",
+      "healthbot_337_1",
+      "0x0000000000000000000000000000000000000000",
+      "--privateKey",
+      privateKey,
+    ])
+      .command(mod)
+      .parse();
+    assert.calledWith(
+      consoleError,
+      "unsupported chain (see `chains` command for details)"
+    );
+  });
 
   test("throws with invalid table name", async function () {
     const [account] = getAccounts();
@@ -43,7 +60,7 @@ describe("commands/transfer", function () {
     );
   });
 
-  test("throws with invalid receiver", async function () {
+  test("throws with invalid receiver address", async function () {
     const [account] = getAccounts();
     const privateKey = account.privateKey.slice(2);
     const consoleError = spy(console, "error");
@@ -64,10 +81,8 @@ describe("commands/transfer", function () {
     );
   });
 
-  test("throws with invalid privateKey", async function () {});
-
   // Does transfering table have knock-on effects on other tables?
-  test("receives receipt", async function () {
+  test("Write passes with local-tableland", async function () {
     const [account1, account2] = getAccounts();
     const account2Address = account2.address;
     console.log(account1.address, account2Address);

--- a/test/transfer.test.ts
+++ b/test/transfer.test.ts
@@ -85,7 +85,6 @@ describe("commands/transfer", function () {
   test("Write passes with local-tableland", async function () {
     const [account1, account2] = getAccounts();
     const account2Address = account2.address;
-    console.log(account1.address, account2Address);
     const consoleLog = spy(console, "log");
     const privateKey = account1.privateKey.slice(2);
     await yargs([
@@ -105,7 +104,6 @@ describe("commands/transfer", function () {
       match(function (value: any) {
         value = JSON.parse(value);
         const { to, from } = value;
-        console.log(to, from);
         return (
           from === account1.address &&
           to === helpers.getContractAddress("local-tableland")

--- a/test/transfer.test.ts
+++ b/test/transfer.test.ts
@@ -34,8 +34,10 @@ describe("commands/transfer", function () {
     const consoleError = spy(console, "error");
     await yargs([
       "transfer",
-      "healthbot_337_1",
+      "healthbot_31337_1",
       "0x0000000000000000000000000000000000000000",
+      "--chain",
+      "does-not-exist",
       "--privateKey",
       privateKey,
     ])

--- a/test/transfer.test.ts
+++ b/test/transfer.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, afterEach, before } from "mocha";
+import { spy, restore, assert, match } from "sinon";
+import yargs from "yargs/yargs";
+import { getAccounts } from "@tableland/local";
+import * as mod from "../src/commands/transfer.js";
+import { wait } from "../src/utils.js";
+import { helpers } from "@tableland/sdk";
+
+describe("commands/transfer", function () {
+  this.timeout("30s");
+
+  before(async function () {
+    await wait(10000);
+  });
+
+  afterEach(function () {
+    restore();
+  });
+
+  test("throws without privateKey", async function () {
+    const consoleError = spy(console, "error");
+    await yargs(["transfer", "healthbot_31337_1", "0x0000000000000000000000"])
+      .command(mod)
+      .parse();
+    assert.calledWith(
+      consoleError,
+      "No registry. This may be because you did not specify a private key with which to interact with the registry."
+    );
+  });
+
+  test("throws with invalid chain", async function () {});
+
+  test("throws with invalid table name", async function () {
+    const [account] = getAccounts();
+    const privateKey = account.privateKey.slice(2);
+    const consoleError = spy(console, "error");
+    await yargs(["transfer", "healthbot", "blah", "-k", privateKey])
+      .command(mod)
+      .parse();
+    assert.calledWith(
+      consoleError,
+      "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
+    );
+  });
+
+  test("throws with invalid receiver", async function () {
+    const [account] = getAccounts();
+    const privateKey = account.privateKey.slice(2);
+    const consoleError = spy(console, "error");
+    await yargs([
+      "transfer",
+      "healthbot_31337_1",
+      "0x00",
+      "--privateKey",
+      privateKey,
+      "--chain",
+      "local-tableland",
+    ])
+      .command(mod)
+      .parse();
+    assert.calledWith(
+      consoleError,
+      'invalid address (argument="address", value="0x00", code=INVALID_ARGUMENT, version=address/5.7.0)'
+    );
+  });
+
+  test("throws with invalid privateKey", async function () {});
+
+  // Does transfering table have knock-on effects on other tables?
+  test("receives receipt", async function () {
+    const [account1, account2] = getAccounts();
+    const account2Address = account2.address;
+    console.log(account1.address, account2Address);
+    const consoleLog = spy(console, "log");
+    const privateKey = account1.privateKey.slice(2);
+    await yargs([
+      "transfer",
+      "healthbot_31337_1",
+      account2Address,
+      "--privateKey",
+      privateKey,
+      "--chain",
+      "local-tableland",
+    ])
+      .command(mod)
+      .parse();
+
+    assert.calledWith(
+      consoleLog,
+      match(function (value: any) {
+        value = JSON.parse(value);
+        const { to, from } = value;
+        console.log(to, from);
+        return (
+          from === account1.address &&
+          to === helpers.getContractAddress("local-tableland")
+        );
+      }, "does not match")
+    );
+  });
+});

--- a/test/transfer.test.ts
+++ b/test/transfer.test.ts
@@ -10,7 +10,7 @@ describe("commands/transfer", function () {
   this.timeout("30s");
 
   before(async function () {
-    await wait(10000);
+    await wait(500);
   });
 
   afterEach(function () {


### PR DESCRIPTION
Description
This PR adds a `transfer` command. This enhancement allows users to easily transfer tables across accounts through the CLI

Usage: 
```bash
tableland transfer <tableName> <destinationAccountAddress>
```
Requires privateKey flag, or for for private key to be set in `.tablelandrc` file.

This PR completes the work for JSTC-8. 

Existing tests pass, new tests added for the transfer command.