### PR TITLE
[JSTC-9] Support extract and unwrap options in read command

### DIFF
--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -74,6 +74,46 @@ describe("commands/read", function () {
     );
   });
 
+  test("passes with extract option", async function () {
+    const consoleLog = spy(console, "log");
+    await yargs([
+      "read",
+      "select counter from healthbot_31337_1;",
+      "--extract",
+      "--chain",
+      "local-tableland",
+    ])
+      .command(mod)
+      .parse();
+    assert.calledWith(
+      consoleLog,
+      match((value) => {
+        value = JSON.parse(value);
+        return Array.isArray(value) && value.includes(1);
+      }, "Doesn't match expected output")
+    );
+  });
+
+  test("passes with unwrap option", async function () {
+    const consoleLog = spy(console, "log");
+    await yargs([
+      "read",
+      "select counter from healthbot_31337_1 where counter = 1;",
+      "--unwrap",
+      "--chain",
+      "local-tableland",
+    ])
+      .command(mod)
+      .parse();
+    assert.calledWith(
+      consoleLog,
+      match((value) => {
+        value = JSON.parse(value);
+        return value.counter === 1;
+      }, "Doesn't match expected output")
+    );
+  });
+
   test("Read passes with local-tableland (defaults to 'objects' format)", async function () {
     const consoleLog = spy(console, "log");
     await yargs(["read", "select * from healthbot_31337_1"])


### PR DESCRIPTION
This PR introduces an enhancement to the SDK's validator, enabling users to dynamically use the "extract" and "unwrap" flags to manipulate returned data more efficiently. The extract flag simplifies a response to the values of a single column, while the unwrap flag simplifies it to the values of a single row. When used together, they allow for requesting a single value from the database without any encapsulating object.

Currently, the "chain" argument is required to use either of these features, as the "Validator" class is the only one supporting unwrap and extract options. A Validator instance mandates a baseUrl for the validator or a chain. We could look at trying to extract the chain from the query, but this should be handle on the SDK, not the CLI.

To improve the SDK and CLI's usability, we propose allowing for a generic validator instance that dynamically decides which validator to use based on the query, similar to the Database instance. This enhancement would necessitate an update to the SDK.

To ensure the responses are as expected, tests have been added to validate the functionality of the proposed changes.

Example: 

```bash
tableland read "select * from healthbot_31337_1 limit 1;" --unwrap --chain "local-tableland"
// Result: {"counter":1}
```
```bash 
tableland read "select counter from healthbot 31337_1;" --extract --chain "local-tableland"
// Result: [1]
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
