### PR TITLE
[JSTC-10] Add more testing to shell command, replace untestable code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,6 @@
         "@ensdomains/ensjs": "3.0.0-alpha.52",
         "@tableland/sdk": "4.0.2",
         "@tableland/sqlparser": "1.0.5",
-        "chalk": "^5.1.2",
-        "cli-select": "^1.1.2",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^8.0.0",
         "dotenv": "^16.0.3",
@@ -21,6 +19,7 @@
         "inquirer": "^9.1.2",
         "js-yaml": "^4.1.0",
         "node-fetch": "^3.2.10",
+        "readline": "^1.3.0",
         "table": "^6.8.1",
         "yargs": "^17.6.2"
       },
@@ -4317,13 +4316,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-select": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^3.2.0"
       }
     },
     "node_modules/cli-select-2": {
@@ -14931,6 +14923,11 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/readline": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
+      "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg=="
+    },
     "node_modules/rechoir": {
       "version": "0.6.2",
       "dev": true,
@@ -21473,12 +21470,6 @@
       "version": "4.0.0",
       "requires": {
         "restore-cursor": "^4.0.0"
-      }
-    },
-    "cli-select": {
-      "version": "1.1.2",
-      "requires": {
-        "ansi-escapes": "^3.2.0"
       }
     },
     "cli-select-2": {
@@ -28884,6 +28875,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "readline": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
+      "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg=="
     },
     "rechoir": {
       "version": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -70,8 +70,6 @@
     "@ensdomains/ensjs": "3.0.0-alpha.52",
     "@tableland/sdk": "4.0.2",
     "@tableland/sqlparser": "1.0.5",
-    "chalk": "^5.1.2",
-    "cli-select": "^1.1.2",
     "cli-select-2": "^2.0.0",
     "cosmiconfig": "^8.0.0",
     "dotenv": "^16.0.3",
@@ -79,6 +77,7 @@
     "inquirer": "^9.1.2",
     "js-yaml": "^4.1.0",
     "node-fetch": "^3.2.10",
+    "readline": "^1.3.0",
     "table": "^6.8.1",
     "yargs": "^17.6.2"
   }


### PR DESCRIPTION
The PR was initiated to add more robust testing to the shell command of the CLI. 


Key changes:

- Refactor the confirmQuery function to handle user input more effectively.
- Add tests to confirm transaction execution based on user input (y/n).
- Improve test coverage by adding additional test cases for the shell comma

Note: 
The CLI command library for select options was very uncooperative with tests, _and_ less convention in it's approach to a yes/no question, so it was replaced with a simple 'readline' for 'y' or 'n'. 

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
