### PR TITLE
[JSTC-5] Add flag for mapping table prefix to ENS subdomain in table creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "dist/**/*.js"
   ],
   "scripts": {
-    "lint": "eslint '**/*.{js,ts}'",
+    "lint": "eslint \"**/*.{js,ts}\"",
     "lint:fix": "npm run lint -- --fix",
-    "prettier": "prettier '**/*.{ts,json,sol,md}' --check",
+    "prettier": "prettier \"**/*.{ts,json,sol,md}\" --check",
     "prettier:fix": "npm run prettier -- --write",
     "format": "npm run prettier:fix && npm run lint:fix",
     "prepublishOnly": "npm run build",

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -86,13 +86,13 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
 
     const res = await db.prepare(statement).all();
     const link = getLink(chain, res.meta.txn?.transactionHash as string);
-    const out = { ...res, link };
+    const out = { ...res, link, ensNameRegistered: false };
 
     if (!check && argv.ns && argv.enableEnsExperiment && prefix) {
-      const register = await ens?.addTableRecords(argv.ns, [
+      const register = (await ens?.addTableRecords(argv.ns, [
         { key: prefix, value: out.meta.txn?.name as string },
-      ]);
-      console.log(register);
+      ])) as boolean;
+      out.ensNameRegistered = register;
     }
 
     console.log(JSON.stringify(out));

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -10,9 +10,10 @@ export interface Options extends GlobalOptions {
   schema?: string;
   prefix?: string;
   file?: string;
+  ns?: string;
 }
 
-export const command = "create [schema]";
+export const command = "create [schema] [prefix]";
 export const desc = "Create a new table";
 
 export const builder: CommandBuilder<{}, Options> = (yargs) =>
@@ -26,6 +27,10 @@ export const builder: CommandBuilder<{}, Options> = (yargs) =>
       type: "string",
       description:
         "Table name prefix (ignored if full create statement is provided)",
+    })
+    .option("ns", {
+      type: "string",
+      description: "ENS namespace to resolve schema from (experimental)",
     })
     .option("file", {
       alias: "f",
@@ -62,6 +67,9 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
 
     let statement = "";
 
+    // now that we have parsed the command args, run the create operation
+    const { database: db, ens } = await setupCommand(argv);
+
     const check = /CREATE TABLE/gim.exec(schema.toString());
     if (check) {
       statement = schema;
@@ -73,15 +81,20 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
       statement = `CREATE TABLE ${prefix} (${schema})`;
     }
 
-    // now that we have parsed the command args, run the create operation
-    const { database: db, ens } = await setupCommand(argv);
-
     if (argv.enableEnsExperiment && ens)
       statement = await ens.resolve(statement);
 
     const res = await db.prepare(statement).all();
     const link = getLink(chain, res.meta.txn?.transactionHash as string);
     const out = { ...res, link };
+
+    if (!check && argv.ns && argv.enableEnsExperiment && prefix) {
+      const register = await ens?.addTableRecords(argv.ns, [
+        { key: prefix, value: out.meta.txn?.name as string },
+      ]);
+      console.log(register);
+    }
+
     console.log(JSON.stringify(out));
     /* c8 ignore next 3 */
   } catch (err: any) {

--- a/src/commands/namespace.ts
+++ b/src/commands/namespace.ts
@@ -22,7 +22,7 @@ async function getHandler(argv: yargs.ArgumentsCamelCase<Options>) {
     return;
   }
 
-  console.log(await ens.resolveTable(record));
+  console.log(JSON.stringify({ value: await ens.resolveTable(record) }));
 }
 
 async function setHandler(argv: yargs.ArgumentsCamelCase<Options>) {

--- a/src/lib/EnsCommand.ts
+++ b/src/lib/EnsCommand.ts
@@ -1,0 +1,6 @@
+// Allows for mocking the ENS export
+import { ENS } from "@ensdomains/ensjs";
+
+export default {
+  ENS,
+};

--- a/src/lib/EnsResolver.ts
+++ b/src/lib/EnsResolver.ts
@@ -51,7 +51,7 @@ export default class EnsResolver {
       console.log("Adding table to ENS failed");
       console.error(e.message);
     }
-    return false;
+    return true;
   }
 
   async resolve(statement: string): Promise<string> {

--- a/src/lib/EnsResolver.ts
+++ b/src/lib/EnsResolver.ts
@@ -1,6 +1,7 @@
 import ethers, { Signer } from "ethers";
-import { ENS } from "@ensdomains/ensjs";
+import ensLib from "./EnsCommand";
 import { JsonRpcProvider } from "@ethersproject/providers";
+import { ENS } from "@ensdomains/ensjs";
 
 interface EnsResolverOptions {
   ensProviderUrl: string;
@@ -23,7 +24,7 @@ export default class EnsResolver {
     this.signer = signer;
     this.provider = new JsonRpcProvider(ensProviderUrl);
 
-    this.ENS = new ENS().withProvider(this.provider);
+    this.ENS = new ensLib.ENS().withProvider(this.provider);
   }
 
   async resolveTable(tablename: string): Promise<string> {
@@ -34,20 +35,6 @@ export default class EnsResolver {
     const address = await this.provider.getResolver(domain);
 
     return (await address?.getText(textRecord)) || tablename;
-  }
-
-  async isOwner(domain: string) {
-    const signer = this.provider.getSigner();
-    if (signer === undefined) throw new Error("No signer");
-    try {
-      const record = await this.ENS.getOwner(domain);
-      if (record?.owner === (await signer.getAddress())) {
-        return true;
-      }
-    } catch (e) {
-      console.log(e);
-      return false;
-    }
   }
 
   async addTableRecords(domain: string, maps: TableMap[]) {

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -6,7 +6,6 @@ import mockStd from "mock-stdin";
 import { getAccounts } from "@tableland/local";
 import * as mod from "../src/commands/create.js";
 import { wait } from "../src/utils.js";
-import { ENSMock } from "./mocks.js";
 import { ethers } from "ethers";
 
 describe("commands/create", function () {
@@ -48,17 +47,17 @@ describe("commands/create", function () {
   });
 
   test("Create namespace with table using ENS", async () => {
-    stub(ethers.providers.JsonRpcProvider.prototype, "getResolver")
+    stub(ethers.providers.Resolver.prototype, "getText")
       // @ts-ignore
-      .callsFake(ENSMock);
+      .callsFake(() => "healthbot_31337_1");
 
     const consoleLog = spy(console, "log");
     const [account] = getAccounts();
     const privateKey = account.privateKey.slice(2);
     await yargs([
       "create",
-      "id integer primary key, message text",
-      "cooltable",
+      "id integer, message text",
+      "hello",
       "--chain",
       "local-tableland",
       "--privateKey",
@@ -67,7 +66,7 @@ describe("commands/create", function () {
       "foo.bar.eth",
       "--enableEnsExperiment",
       "--ensProviderUrl",
-      "https://localhost:7070",
+      "https://localhost:8080",
     ])
       .command(mod)
       .parse();
@@ -76,7 +75,7 @@ describe("commands/create", function () {
       consoleLog,
       match(function (value: any) {
         value = JSON.parse(value);
-        return value.name === "foo.bar.eth" && value.ensNameRegistered === true;
+        return value.ensNameRegistered === true;
       })
     );
   });

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -7,6 +7,7 @@ import { getAccounts } from "@tableland/local";
 import * as mod from "../src/commands/create.js";
 import { wait } from "../src/utils.js";
 import { ethers } from "ethers";
+import { getResolverMock } from "./mock.js";
 
 describe("commands/create", function () {
   this.timeout("30s");
@@ -50,14 +51,7 @@ describe("commands/create", function () {
     const fullReolverStub = stub(
       ethers.providers.JsonRpcProvider.prototype,
       "getResolver"
-    ).callsFake(
-      // @ts-ignore
-      () => {
-        return {
-          getText: () => "healthbot_31337_1",
-        };
-      }
-    );
+    ).callsFake(getResolverMock);
 
     const consoleLog = spy(console, "log");
     const [account] = getAccounts();

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -1,0 +1,5 @@
+export const getResolverMock = async (): Promise<any> => {
+  return {
+    getText: async () => "healthbot_31337_1",
+  };
+};

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -1,0 +1,7 @@
+export const ENSMock = async () => {
+  return {
+    getText: async () => {
+      return "healthbot_31337_1";
+    },
+  };
+};

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -1,7 +1,0 @@
-export const ENSMock = async () => {
-  return {
-    getText: async () => {
-      return "healthbot_31337_1";
-    },
-  };
-};

--- a/test/namespace.test.ts
+++ b/test/namespace.test.ts
@@ -4,6 +4,7 @@ import yargs from "yargs/yargs";
 import * as mod from "../src/commands/namespace.js";
 import ensLib from "../src/lib/EnsCommand";
 import { ethers } from "ethers";
+import { getResolverMock } from "./mock.js";
 
 describe("commands/namespace", function () {
   beforeEach(async function () {
@@ -22,13 +23,7 @@ describe("commands/namespace", function () {
 
     stub(ethers.providers.JsonRpcProvider.prototype, "getResolver")
       // @ts-ignore
-      .callsFake(async () => {
-        return {
-          getText: async () => {
-            return "healthbot_31337_1";
-          },
-        };
-      });
+      .callsFake(getResolverMock);
   });
 
   afterEach(function () {

--- a/test/namespace.test.ts
+++ b/test/namespace.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, afterEach, beforeEach } from "mocha";
+import { spy, restore, assert, stub, match } from "sinon";
+import yargs from "yargs/yargs";
+import * as mod from "../src/commands/namespace.js";
+import ensLib from "../src/lib/EnsCommand";
+import { ethers } from "ethers";
+
+describe("commands/namespace", function () {
+  beforeEach(async function () {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    stub(ensLib, "ENS").callsFake(function () {
+      return {
+        withProvider: () => {
+          return {
+            setRecords: async () => {
+              return false;
+            },
+          };
+        },
+      };
+    });
+
+    stub(ethers.providers.JsonRpcProvider.prototype, "getResolver")
+      // @ts-ignore
+      .callsFake(async () => {
+        return {
+          getText: async () => {
+            return "healthbot_31337_1";
+          },
+        };
+      });
+  });
+
+  afterEach(function () {
+    restore();
+  });
+
+  test("Get ENS name", async function () {
+    const consoleLog = spy(console, "log");
+    await yargs([
+      "namespace",
+      "get",
+      "foo.bar.eth",
+      "--enableEnsExperiment",
+      "--ensProviderUrl",
+      "https://localhost:7070",
+    ])
+      .command(mod)
+      .parse();
+
+    assert.calledWith(
+      consoleLog,
+      match((value) => {
+        value = JSON.parse(value);
+
+        return value.value === "healthbot_31337_1";
+      }, "Doesn't match expected output")
+    );
+  });
+
+  test("Set ENS name", async function () {
+    const consoleLog = spy(console, "log");
+    await yargs([
+      "namespace",
+      "set",
+      "foo.bar.eth",
+      "healthbot=healthbot_31337_1",
+      "--enableEnsExperiment",
+      "--ensProviderUrl",
+      "https://localhost:7070",
+    ])
+      .command(mod)
+      .parse();
+
+    assert.calledWith(
+      consoleLog,
+      match((value) => {
+        value = JSON.parse(value);
+
+        return (
+          value.domain === "foo.bar.eth" &&
+          value.records[0].key === "healthbot" &&
+          value.records[0].value === "healthbot_31337_1"
+        );
+      }, "Doesn't match expected output")
+    );
+  });
+});

--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -148,7 +148,7 @@ describe("commands/read", function () {
     );
   });
 
-  test("ENS flag transform name", async function () {
+  test("ENS experimental replaces shorthand with tablename", async function () {
     stub(ethers.providers.JsonRpcProvider.prototype, "getResolver")
       // @ts-ignore
       .callsFake(async () => {

--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -149,9 +149,17 @@ describe("commands/read", function () {
   });
 
   test("ENS experimental replaces shorthand with tablename", async function () {
-    stub(ethers.providers.Resolver.prototype, "getText")
+    const fullReolverStub = stub(
+      ethers.providers.JsonRpcProvider.prototype,
+      "getResolver"
+    ).callsFake(
       // @ts-ignore
-      .callsFake(() => "healthbot_31337_1");
+      () => {
+        return {
+          getText: () => "healthbot_31337_1",
+        };
+      }
+    );
     const consoleLog = spy(console, "log");
     await yargs([
       "read",
@@ -164,6 +172,8 @@ describe("commands/read", function () {
     ])
       .command(mod)
       .parse();
+
+    fullReolverStub.restore();
 
     assert.calledWith(
       consoleLog,

--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -6,7 +6,6 @@ import mockStd from "mock-stdin";
 import * as mod from "../src/commands/read.js";
 import { wait } from "../src/utils.js";
 import { ethers } from "ethers";
-import { ENSMock } from "./mocks.js";
 
 describe("commands/read", function () {
   this.timeout(10000);
@@ -150,9 +149,9 @@ describe("commands/read", function () {
   });
 
   test("ENS experimental replaces shorthand with tablename", async function () {
-    stub(ethers.providers.JsonRpcProvider.prototype, "getResolver")
+    stub(ethers.providers.Resolver.prototype, "getText")
       // @ts-ignore
-      .callsFake(ENSMock);
+      .callsFake(() => "healthbot_31337_1");
     const consoleLog = spy(console, "log");
     await yargs([
       "read",

--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -6,6 +6,7 @@ import mockStd from "mock-stdin";
 import * as mod from "../src/commands/read.js";
 import { wait } from "../src/utils.js";
 import { ethers } from "ethers";
+import { getResolverMock } from "./mock.js";
 
 describe("commands/read", function () {
   this.timeout(10000);
@@ -152,14 +153,7 @@ describe("commands/read", function () {
     const fullReolverStub = stub(
       ethers.providers.JsonRpcProvider.prototype,
       "getResolver"
-    ).callsFake(
-      // @ts-ignore
-      () => {
-        return {
-          getText: () => "healthbot_31337_1",
-        };
-      }
-    );
+    ).callsFake(getResolverMock);
     const consoleLog = spy(console, "log");
     await yargs([
       "read",

--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -6,6 +6,7 @@ import mockStd from "mock-stdin";
 import * as mod from "../src/commands/read.js";
 import { wait } from "../src/utils.js";
 import { ethers } from "ethers";
+import { ENSMock } from "./mocks.js";
 
 describe("commands/read", function () {
   this.timeout(10000);
@@ -151,13 +152,7 @@ describe("commands/read", function () {
   test("ENS experimental replaces shorthand with tablename", async function () {
     stub(ethers.providers.JsonRpcProvider.prototype, "getResolver")
       // @ts-ignore
-      .callsFake(async () => {
-        return {
-          getText: async () => {
-            return "healthbot_31337_1";
-          },
-        };
-      });
+      .callsFake(ENSMock);
     const consoleLog = spy(console, "log");
     await yargs([
       "read",

--- a/test/shell.test.ts
+++ b/test/shell.test.ts
@@ -48,9 +48,7 @@ describe("commands/shell", function () {
     const fullReolverStub = stub(
       ethers.providers.JsonRpcProvider.prototype,
       "getResolver"
-    ).callsFake(
-      getResolverMock
-    );
+    ).callsFake(getResolverMock);
 
     const consoleLog = spy(console, "log");
     const stdin = mockStd.stdin();

--- a/test/shell.test.ts
+++ b/test/shell.test.ts
@@ -6,7 +6,6 @@ import { getAccounts } from "@tableland/local";
 import * as mod from "../src/commands/shell.js";
 import { wait } from "../src/utils.js";
 import { ethers } from "ethers";
-import { ENSMock } from "./mocks.js";
 
 describe("commands/shell", function () {
   this.timeout("30s");
@@ -45,9 +44,9 @@ describe("commands/shell", function () {
   });
 
   test("ENS in shell with single line", async function () {
-    stub(ethers.providers.JsonRpcProvider.prototype, "getResolver")
+    stub(ethers.providers.Resolver.prototype, "getText")
       // @ts-ignore
-      .callsFake(ENSMock);
+      .callsFake(() => "healthbot_31337_1");
 
     const consoleLog = spy(console, "log");
     const stdin = mockStd.stdin();

--- a/test/shell.test.ts
+++ b/test/shell.test.ts
@@ -44,9 +44,17 @@ describe("commands/shell", function () {
   });
 
   test("ENS in shell with single line", async function () {
-    stub(ethers.providers.Resolver.prototype, "getText")
+    const fullReolverStub = stub(
+      ethers.providers.JsonRpcProvider.prototype,
+      "getResolver"
+    ).callsFake(
       // @ts-ignore
-      .callsFake(() => "healthbot_31337_1");
+      () => {
+        return {
+          getText: () => "healthbot_31337_1",
+        };
+      }
+    );
 
     const consoleLog = spy(console, "log");
     const stdin = mockStd.stdin();
@@ -71,6 +79,8 @@ describe("commands/shell", function () {
     ])
       .command(mod)
       .parse();
+
+    fullReolverStub.reset();
 
     assert.match(consoleLog.getCall(4).args[0], '[{"counter":1}]');
   });

--- a/test/shell.test.ts
+++ b/test/shell.test.ts
@@ -6,6 +6,7 @@ import { getAccounts } from "@tableland/local";
 import * as mod from "../src/commands/shell.js";
 import { wait } from "../src/utils.js";
 import { ethers } from "ethers";
+import { getResolverMock } from "./mock.js";
 
 describe("commands/shell", function () {
   this.timeout("30s");
@@ -48,12 +49,7 @@ describe("commands/shell", function () {
       ethers.providers.JsonRpcProvider.prototype,
       "getResolver"
     ).callsFake(
-      // @ts-ignore
-      () => {
-        return {
-          getText: () => "healthbot_31337_1",
-        };
-      }
+      getResolverMock
     );
 
     const consoleLog = spy(console, "log");


### PR DESCRIPTION
This pull request introduces a new flag that allows users to map a table's prefix to an existing Ethereum Name Service (ENS) subdomain when creating a table on the Tableland network.

Please note that this feature does not enable users to simultaneously register an ENS domain or subdomain. The wallet provided must already be the controller of an existing domain or subdomain in order to register a prefix with it.

Example usage:

```bash
> tableland create --ns myapp.foo.eth "id integer primary key, item text, count int" inventory
```
In this example, the command creates a table with the specified schema. Once the table is successfully created on the Tableland network, it registers the text record "inventory" to, for example, "Inventory_1_414" on the Tableland network, associating it with the specified ENS subdomain. In tableland, `inventory.myapp.foo.eth` will now refer to Inventory_1_414.


