### PR TITLE
update tableland dependencies and fix ens after upgrade of sql parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@ensdomains/ensjs": "3.0.0-alpha.57",
-        "@tableland/sdk": "^4.1.0",
+        "@tableland/sdk": "^4.2.1",
         "@tableland/sqlparser": "^1.0.5",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^8.0.0",
@@ -27,7 +27,7 @@
         "tableland": "dist/cli.js"
       },
       "devDependencies": {
-        "@tableland/local": "^1.0.0",
+        "@tableland/local": "^1.2.1",
         "@types/cosmiconfig": "^6.0.0",
         "@types/inquirer": "^9.0.2",
         "@types/js-yaml": "^4.0.5",
@@ -1089,22 +1089,22 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@tableland/evm": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.1.0.tgz",
-      "integrity": "sha512-1/qIewZo5//2egVxZwjZyo8TySDGzlF8swdxMjvPeVVx9OJprT8ttF8nJmMtKIBNK0b4HkvW/qA2AqP8cOGcQg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.2.1.tgz",
+      "integrity": "sha512-1CwQUSOChfurTPWq1VvAz+sw/ARMV628O+IngV/6+iPF7MinKIMAVHRciPgXI5sOI7hnwXIiQIN8kHCiVSfzZg==",
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@tableland/local": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.1.0.tgz",
-      "integrity": "sha512-3M6Qqt3D6yudF0JZauRB4fJa7tLXWpewrIliQhLdsxNVbBOQpsQ1WHZ9fLJqoV0yqBREE9gFzEiDjSjSunX9Mw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.2.1.tgz",
+      "integrity": "sha512-8NbZAzgbome7AQ/yf0rfpz5MTs4tUgrYBRZcCGXeOUzwx4lFefqGQIHrCtKtokGpNJPSKMLRFYko+bc9JwIuNA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@tableland/sdk": "^4.0.2",
-        "@tableland/validator": "^1.1.0",
+        "@tableland/sdk": "^4.2.0",
+        "@tableland/validator": "^1.2.2",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
         "ethers": "^5.7.2",
@@ -1119,11 +1119,11 @@
       }
     },
     "node_modules/@tableland/sdk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.1.0.tgz",
-      "integrity": "sha512-aEqgwd5OFau67u5eu5rFjf5Kl+P2ju6/QmDfHIa4arIUv8ZGYfaMaM+p6Bw/ZQqzKqxBwGL8gigZY+983RgCFg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.2.1.tgz",
+      "integrity": "sha512-otarWPmiUTKWtfUBh9mp7qcIKNmIECNeaopyAkf+76GHzKYociAeFNKkMHx8Y10GOaaBO2nx3NQObbkUZRfM0A==",
       "dependencies": {
-        "@tableland/evm": "^4.1.0",
+        "@tableland/evm": "^4.2.1",
         "@tableland/sqlparser": "^1.0.5",
         "ethers": "^5.7.2"
       }
@@ -1134,9 +1134,9 @@
       "integrity": "sha512-dotXZulYNKdxLNbGkenQGAjuQfuXFRcxUqtt8ffyoNG3n6llUVOnTVXWjcSL0B36kMSVul7XpfKSQkGOa13awg=="
     },
     "node_modules/@tableland/validator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.1.0.tgz",
-      "integrity": "sha512-eaz8C5k4kQa8NLxrYM17i778bFbw124iTKgwnJhBbkRTQ0+KOcq2tUWAgzCk5pmpGZz5Tfy40sD7UcbfRDlDfg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.2.2.tgz",
+      "integrity": "sha512-xAzra1KRTl/q3zvjVOgxorNr24qYfFx7g4WDAQQb2CeO7oJv6hsmEH3Iwe2O9MY94mrLTO+DJG+Zwjs/Z5a+JQ==",
       "dev": true
     },
     "node_modules/@tsconfig/node10": {
@@ -7062,18 +7062,18 @@
       "dev": true
     },
     "@tableland/evm": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.1.0.tgz",
-      "integrity": "sha512-1/qIewZo5//2egVxZwjZyo8TySDGzlF8swdxMjvPeVVx9OJprT8ttF8nJmMtKIBNK0b4HkvW/qA2AqP8cOGcQg=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.2.1.tgz",
+      "integrity": "sha512-1CwQUSOChfurTPWq1VvAz+sw/ARMV628O+IngV/6+iPF7MinKIMAVHRciPgXI5sOI7hnwXIiQIN8kHCiVSfzZg=="
     },
     "@tableland/local": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.1.0.tgz",
-      "integrity": "sha512-3M6Qqt3D6yudF0JZauRB4fJa7tLXWpewrIliQhLdsxNVbBOQpsQ1WHZ9fLJqoV0yqBREE9gFzEiDjSjSunX9Mw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.2.1.tgz",
+      "integrity": "sha512-8NbZAzgbome7AQ/yf0rfpz5MTs4tUgrYBRZcCGXeOUzwx4lFefqGQIHrCtKtokGpNJPSKMLRFYko+bc9JwIuNA==",
       "dev": true,
       "requires": {
-        "@tableland/sdk": "^4.0.2",
-        "@tableland/validator": "^1.1.0",
+        "@tableland/sdk": "^4.2.0",
+        "@tableland/validator": "^1.2.2",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
         "ethers": "^5.7.2",
@@ -7082,11 +7082,11 @@
       }
     },
     "@tableland/sdk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.1.0.tgz",
-      "integrity": "sha512-aEqgwd5OFau67u5eu5rFjf5Kl+P2ju6/QmDfHIa4arIUv8ZGYfaMaM+p6Bw/ZQqzKqxBwGL8gigZY+983RgCFg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.2.1.tgz",
+      "integrity": "sha512-otarWPmiUTKWtfUBh9mp7qcIKNmIECNeaopyAkf+76GHzKYociAeFNKkMHx8Y10GOaaBO2nx3NQObbkUZRfM0A==",
       "requires": {
-        "@tableland/evm": "^4.1.0",
+        "@tableland/evm": "^4.2.1",
         "@tableland/sqlparser": "^1.0.5",
         "ethers": "^5.7.2"
       }
@@ -7097,9 +7097,9 @@
       "integrity": "sha512-dotXZulYNKdxLNbGkenQGAjuQfuXFRcxUqtt8ffyoNG3n6llUVOnTVXWjcSL0B36kMSVul7XpfKSQkGOa13awg=="
     },
     "@tableland/validator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.1.0.tgz",
-      "integrity": "sha512-eaz8C5k4kQa8NLxrYM17i778bFbw124iTKgwnJhBbkRTQ0+KOcq2tUWAgzCk5pmpGZz5Tfy40sD7UcbfRDlDfg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.2.2.tgz",
+      "integrity": "sha512-xAzra1KRTl/q3zvjVOgxorNr24qYfFx7g4WDAQQb2CeO7oJv6hsmEH3Iwe2O9MY94mrLTO+DJG+Zwjs/Z5a+JQ==",
       "dev": true
     },
     "@tsconfig/node10": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@ensdomains/ensjs": "3.0.0-alpha.57",
-        "@tableland/sdk": "^4.2.2-pre.0",
-        "@tableland/sqlparser": "^1.0.6-pre.5",
+        "@tableland/sdk": "^4.2.2",
+        "@tableland/sqlparser": "^1.0.6",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^8.0.0",
         "dotenv": "^16.0.3",
@@ -27,7 +27,7 @@
         "tableland": "dist/cli.js"
       },
       "devDependencies": {
-        "@tableland/local": "^1.2.2-pre.1",
+        "@tableland/local": "^1.2.2",
         "@types/cosmiconfig": "^6.0.0",
         "@types/inquirer": "^9.0.2",
         "@types/js-yaml": "^4.0.5",
@@ -1097,9 +1097,9 @@
       }
     },
     "node_modules/@tableland/local": {
-      "version": "1.2.2-pre.1",
-      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.2.2-pre.1.tgz",
-      "integrity": "sha512-vBCjwdSkLAAbIR94VYwd77WNyVnmMzFRsUnNX64Gqr1Co29sHnle1F1ZaWaOVC9EwT8coAy++yLLsSynliLGCg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.2.2.tgz",
+      "integrity": "sha512-9AyIx09qd7FMwmALL9uTCaHP8Nw9GhXCNOaZFUlGpasYrU1iUsAHtLBMfHSs2VGl6oHumHhl3nwkWP6WeNiaLg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1118,27 +1118,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tableland/local/node_modules/@tableland/sdk": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.2.1.tgz",
-      "integrity": "sha512-otarWPmiUTKWtfUBh9mp7qcIKNmIECNeaopyAkf+76GHzKYociAeFNKkMHx8Y10GOaaBO2nx3NQObbkUZRfM0A==",
-      "dev": true,
-      "dependencies": {
-        "@tableland/evm": "^4.2.1",
-        "@tableland/sqlparser": "^1.0.5",
-        "ethers": "^5.7.2"
-      }
-    },
-    "node_modules/@tableland/local/node_modules/@tableland/sqlparser": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.5.tgz",
-      "integrity": "sha512-dotXZulYNKdxLNbGkenQGAjuQfuXFRcxUqtt8ffyoNG3n6llUVOnTVXWjcSL0B36kMSVul7XpfKSQkGOa13awg==",
-      "dev": true
-    },
     "node_modules/@tableland/sdk": {
-      "version": "4.2.2-pre.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.2.2-pre.0.tgz",
-      "integrity": "sha512-X1nKsLTBLzM/+uz7ZwfnWU6oRho+RK8i/WVP0ORO5Omn27YyHDqCYJ1inyxGNg0bLYYB52hUL3U8aM6SRSPBSg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.2.2.tgz",
+      "integrity": "sha512-LYqXMtyU0YGizrVlPJmYXgIf+DhV+U1epdVat0zZYksNvO8NRJxx40k7R5ZqMVkB0dhgYdB1ybbsLBD8lLWjXA==",
       "dependencies": {
         "@tableland/evm": "^4.2.2",
         "@tableland/sqlparser": "^1.0.6-pre.5",
@@ -1146,9 +1129,9 @@
       }
     },
     "node_modules/@tableland/sqlparser": {
-      "version": "1.0.6-pre.5",
-      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.6-pre.5.tgz",
-      "integrity": "sha512-HVjpT1FqzwVhlRRm+OPEyJB8JIAgGH/pp6Jxf3vAtMBCMS0zPuUc+2uRlxnIicL5g+qnXQazjU+bGnl2yXHi1Q=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.6.tgz",
+      "integrity": "sha512-fSoR4hslQqcvkjU0JvRG70fWEVOsbJc8177LqaHC2r2DDC2328Kho/t+aeG5qho4gvSuZckDcKEgeCugD1m5Mg=="
     },
     "node_modules/@tableland/validator": {
       "version": "1.3.1",
@@ -7084,9 +7067,9 @@
       "integrity": "sha512-itcUWvnZ4CDujVXlP9SKM49Tfo1mawynf0PooceA76JqGMFKaO1f5LArD7Xss0YOvRMtRpQbELbfNdznIk+FGw=="
     },
     "@tableland/local": {
-      "version": "1.2.2-pre.1",
-      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.2.2-pre.1.tgz",
-      "integrity": "sha512-vBCjwdSkLAAbIR94VYwd77WNyVnmMzFRsUnNX64Gqr1Co29sHnle1F1ZaWaOVC9EwT8coAy++yLLsSynliLGCg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.2.2.tgz",
+      "integrity": "sha512-9AyIx09qd7FMwmALL9uTCaHP8Nw9GhXCNOaZFUlGpasYrU1iUsAHtLBMfHSs2VGl6oHumHhl3nwkWP6WeNiaLg==",
       "dev": true,
       "requires": {
         "@tableland/sdk": "^4.2.1",
@@ -7096,31 +7079,12 @@
         "ethers": "^5.7.2",
         "shelljs": "^0.8.5",
         "yargs": "^17.5.1"
-      },
-      "dependencies": {
-        "@tableland/sdk": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.2.1.tgz",
-          "integrity": "sha512-otarWPmiUTKWtfUBh9mp7qcIKNmIECNeaopyAkf+76GHzKYociAeFNKkMHx8Y10GOaaBO2nx3NQObbkUZRfM0A==",
-          "dev": true,
-          "requires": {
-            "@tableland/evm": "^4.2.1",
-            "@tableland/sqlparser": "^1.0.5",
-            "ethers": "^5.7.2"
-          }
-        },
-        "@tableland/sqlparser": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.5.tgz",
-          "integrity": "sha512-dotXZulYNKdxLNbGkenQGAjuQfuXFRcxUqtt8ffyoNG3n6llUVOnTVXWjcSL0B36kMSVul7XpfKSQkGOa13awg==",
-          "dev": true
-        }
       }
     },
     "@tableland/sdk": {
-      "version": "4.2.2-pre.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.2.2-pre.0.tgz",
-      "integrity": "sha512-X1nKsLTBLzM/+uz7ZwfnWU6oRho+RK8i/WVP0ORO5Omn27YyHDqCYJ1inyxGNg0bLYYB52hUL3U8aM6SRSPBSg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.2.2.tgz",
+      "integrity": "sha512-LYqXMtyU0YGizrVlPJmYXgIf+DhV+U1epdVat0zZYksNvO8NRJxx40k7R5ZqMVkB0dhgYdB1ybbsLBD8lLWjXA==",
       "requires": {
         "@tableland/evm": "^4.2.2",
         "@tableland/sqlparser": "^1.0.6-pre.5",
@@ -7128,9 +7092,9 @@
       }
     },
     "@tableland/sqlparser": {
-      "version": "1.0.6-pre.5",
-      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.6-pre.5.tgz",
-      "integrity": "sha512-HVjpT1FqzwVhlRRm+OPEyJB8JIAgGH/pp6Jxf3vAtMBCMS0zPuUc+2uRlxnIicL5g+qnXQazjU+bGnl2yXHi1Q=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.6.tgz",
+      "integrity": "sha512-fSoR4hslQqcvkjU0JvRG70fWEVOsbJc8177LqaHC2r2DDC2328Kho/t+aeG5qho4gvSuZckDcKEgeCugD1m5Mg=="
     },
     "@tableland/validator": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@ensdomains/ensjs": "3.0.0-alpha.57",
-        "@tableland/sdk": "^4.2.1",
-        "@tableland/sqlparser": "^1.0.5",
+        "@tableland/sdk": "^4.2.2-pre.0",
+        "@tableland/sqlparser": "^1.0.6-pre.5",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^8.0.0",
         "dotenv": "^16.0.3",
@@ -27,7 +27,7 @@
         "tableland": "dist/cli.js"
       },
       "devDependencies": {
-        "@tableland/local": "^1.2.1",
+        "@tableland/local": "^1.2.2-pre.1",
         "@types/cosmiconfig": "^6.0.0",
         "@types/inquirer": "^9.0.2",
         "@types/js-yaml": "^4.0.5",
@@ -1089,22 +1089,22 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@tableland/evm": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.2.1.tgz",
-      "integrity": "sha512-1CwQUSOChfurTPWq1VvAz+sw/ARMV628O+IngV/6+iPF7MinKIMAVHRciPgXI5sOI7hnwXIiQIN8kHCiVSfzZg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.2.2.tgz",
+      "integrity": "sha512-itcUWvnZ4CDujVXlP9SKM49Tfo1mawynf0PooceA76JqGMFKaO1f5LArD7Xss0YOvRMtRpQbELbfNdznIk+FGw==",
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@tableland/local": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.2.1.tgz",
-      "integrity": "sha512-8NbZAzgbome7AQ/yf0rfpz5MTs4tUgrYBRZcCGXeOUzwx4lFefqGQIHrCtKtokGpNJPSKMLRFYko+bc9JwIuNA==",
+      "version": "1.2.2-pre.1",
+      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.2.2-pre.1.tgz",
+      "integrity": "sha512-vBCjwdSkLAAbIR94VYwd77WNyVnmMzFRsUnNX64Gqr1Co29sHnle1F1ZaWaOVC9EwT8coAy++yLLsSynliLGCg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@tableland/sdk": "^4.2.0",
-        "@tableland/validator": "^1.2.2",
+        "@tableland/sdk": "^4.2.1",
+        "@tableland/validator": "^1.3.1",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
         "ethers": "^5.7.2",
@@ -1118,25 +1118,42 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tableland/sdk": {
+    "node_modules/@tableland/local/node_modules/@tableland/sdk": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.2.1.tgz",
       "integrity": "sha512-otarWPmiUTKWtfUBh9mp7qcIKNmIECNeaopyAkf+76GHzKYociAeFNKkMHx8Y10GOaaBO2nx3NQObbkUZRfM0A==",
+      "dev": true,
       "dependencies": {
         "@tableland/evm": "^4.2.1",
         "@tableland/sqlparser": "^1.0.5",
         "ethers": "^5.7.2"
       }
     },
-    "node_modules/@tableland/sqlparser": {
+    "node_modules/@tableland/local/node_modules/@tableland/sqlparser": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.5.tgz",
-      "integrity": "sha512-dotXZulYNKdxLNbGkenQGAjuQfuXFRcxUqtt8ffyoNG3n6llUVOnTVXWjcSL0B36kMSVul7XpfKSQkGOa13awg=="
+      "integrity": "sha512-dotXZulYNKdxLNbGkenQGAjuQfuXFRcxUqtt8ffyoNG3n6llUVOnTVXWjcSL0B36kMSVul7XpfKSQkGOa13awg==",
+      "dev": true
+    },
+    "node_modules/@tableland/sdk": {
+      "version": "4.2.2-pre.0",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.2.2-pre.0.tgz",
+      "integrity": "sha512-X1nKsLTBLzM/+uz7ZwfnWU6oRho+RK8i/WVP0ORO5Omn27YyHDqCYJ1inyxGNg0bLYYB52hUL3U8aM6SRSPBSg==",
+      "dependencies": {
+        "@tableland/evm": "^4.2.2",
+        "@tableland/sqlparser": "^1.0.6-pre.5",
+        "ethers": "^5.7.2"
+      }
+    },
+    "node_modules/@tableland/sqlparser": {
+      "version": "1.0.6-pre.5",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.6-pre.5.tgz",
+      "integrity": "sha512-HVjpT1FqzwVhlRRm+OPEyJB8JIAgGH/pp6Jxf3vAtMBCMS0zPuUc+2uRlxnIicL5g+qnXQazjU+bGnl2yXHi1Q=="
     },
     "node_modules/@tableland/validator": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.2.2.tgz",
-      "integrity": "sha512-xAzra1KRTl/q3zvjVOgxorNr24qYfFx7g4WDAQQb2CeO7oJv6hsmEH3Iwe2O9MY94mrLTO+DJG+Zwjs/Z5a+JQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.3.1.tgz",
+      "integrity": "sha512-FIM+hvxgaaYfTREDcNK4Unj5awjCzA+TmhO0m6eKUgMtty11oiS9UnWzj1J7aHaoHlP9KozptoGv6BHPh3w68A==",
       "dev": true
     },
     "node_modules/@tsconfig/node10": {
@@ -7062,44 +7079,63 @@
       "dev": true
     },
     "@tableland/evm": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.2.1.tgz",
-      "integrity": "sha512-1CwQUSOChfurTPWq1VvAz+sw/ARMV628O+IngV/6+iPF7MinKIMAVHRciPgXI5sOI7hnwXIiQIN8kHCiVSfzZg=="
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.2.2.tgz",
+      "integrity": "sha512-itcUWvnZ4CDujVXlP9SKM49Tfo1mawynf0PooceA76JqGMFKaO1f5LArD7Xss0YOvRMtRpQbELbfNdznIk+FGw=="
     },
     "@tableland/local": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.2.1.tgz",
-      "integrity": "sha512-8NbZAzgbome7AQ/yf0rfpz5MTs4tUgrYBRZcCGXeOUzwx4lFefqGQIHrCtKtokGpNJPSKMLRFYko+bc9JwIuNA==",
+      "version": "1.2.2-pre.1",
+      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.2.2-pre.1.tgz",
+      "integrity": "sha512-vBCjwdSkLAAbIR94VYwd77WNyVnmMzFRsUnNX64Gqr1Co29sHnle1F1ZaWaOVC9EwT8coAy++yLLsSynliLGCg==",
       "dev": true,
       "requires": {
-        "@tableland/sdk": "^4.2.0",
-        "@tableland/validator": "^1.2.2",
+        "@tableland/sdk": "^4.2.1",
+        "@tableland/validator": "^1.3.1",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
         "ethers": "^5.7.2",
         "shelljs": "^0.8.5",
         "yargs": "^17.5.1"
+      },
+      "dependencies": {
+        "@tableland/sdk": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.2.1.tgz",
+          "integrity": "sha512-otarWPmiUTKWtfUBh9mp7qcIKNmIECNeaopyAkf+76GHzKYociAeFNKkMHx8Y10GOaaBO2nx3NQObbkUZRfM0A==",
+          "dev": true,
+          "requires": {
+            "@tableland/evm": "^4.2.1",
+            "@tableland/sqlparser": "^1.0.5",
+            "ethers": "^5.7.2"
+          }
+        },
+        "@tableland/sqlparser": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.5.tgz",
+          "integrity": "sha512-dotXZulYNKdxLNbGkenQGAjuQfuXFRcxUqtt8ffyoNG3n6llUVOnTVXWjcSL0B36kMSVul7XpfKSQkGOa13awg==",
+          "dev": true
+        }
       }
     },
     "@tableland/sdk": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.2.1.tgz",
-      "integrity": "sha512-otarWPmiUTKWtfUBh9mp7qcIKNmIECNeaopyAkf+76GHzKYociAeFNKkMHx8Y10GOaaBO2nx3NQObbkUZRfM0A==",
+      "version": "4.2.2-pre.0",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.2.2-pre.0.tgz",
+      "integrity": "sha512-X1nKsLTBLzM/+uz7ZwfnWU6oRho+RK8i/WVP0ORO5Omn27YyHDqCYJ1inyxGNg0bLYYB52hUL3U8aM6SRSPBSg==",
       "requires": {
-        "@tableland/evm": "^4.2.1",
-        "@tableland/sqlparser": "^1.0.5",
+        "@tableland/evm": "^4.2.2",
+        "@tableland/sqlparser": "^1.0.6-pre.5",
         "ethers": "^5.7.2"
       }
     },
     "@tableland/sqlparser": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.5.tgz",
-      "integrity": "sha512-dotXZulYNKdxLNbGkenQGAjuQfuXFRcxUqtt8ffyoNG3n6llUVOnTVXWjcSL0B36kMSVul7XpfKSQkGOa13awg=="
+      "version": "1.0.6-pre.5",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.6-pre.5.tgz",
+      "integrity": "sha512-HVjpT1FqzwVhlRRm+OPEyJB8JIAgGH/pp6Jxf3vAtMBCMS0zPuUc+2uRlxnIicL5g+qnXQazjU+bGnl2yXHi1Q=="
     },
     "@tableland/validator": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.2.2.tgz",
-      "integrity": "sha512-xAzra1KRTl/q3zvjVOgxorNr24qYfFx7g4WDAQQb2CeO7oJv6hsmEH3Iwe2O9MY94mrLTO+DJG+Zwjs/Z5a+JQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.3.1.tgz",
+      "integrity": "sha512-FIM+hvxgaaYfTREDcNK4Unj5awjCzA+TmhO0m6eKUgMtty11oiS9UnWzj1J7aHaoHlP9KozptoGv6BHPh3w68A==",
       "dev": true
     },
     "@tsconfig/node10": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "license": "MIT AND Apache-2.0",
   "devDependencies": {
-    "@tableland/local": "^1.0.0",
+    "@tableland/local": "^1.2.1",
     "@types/cosmiconfig": "^6.0.0",
     "@types/inquirer": "^9.0.2",
     "@types/js-yaml": "^4.0.5",
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@ensdomains/ensjs": "3.0.0-alpha.57",
-    "@tableland/sdk": "^4.1.0",
+    "@tableland/sdk": "^4.2.1",
     "@tableland/sqlparser": "^1.0.5",
     "cli-select-2": "^2.0.0",
     "cosmiconfig": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "license": "MIT AND Apache-2.0",
   "devDependencies": {
-    "@tableland/local": "^1.2.1",
+    "@tableland/local": "^1.2.2-pre.1",
     "@types/cosmiconfig": "^6.0.0",
     "@types/inquirer": "^9.0.2",
     "@types/js-yaml": "^4.0.5",
@@ -68,8 +68,8 @@
   },
   "dependencies": {
     "@ensdomains/ensjs": "3.0.0-alpha.57",
-    "@tableland/sdk": "^4.2.1",
-    "@tableland/sqlparser": "^1.0.5",
+    "@tableland/sdk": "^4.2.2-pre.0",
+    "@tableland/sqlparser": "^1.0.6-pre.5",
     "cli-select-2": "^2.0.0",
     "cosmiconfig": "^8.0.0",
     "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "license": "MIT AND Apache-2.0",
   "devDependencies": {
-    "@tableland/local": "^1.2.2-pre.1",
+    "@tableland/local": "^1.2.2",
     "@types/cosmiconfig": "^6.0.0",
     "@types/inquirer": "^9.0.2",
     "@types/js-yaml": "^4.0.5",
@@ -68,8 +68,8 @@
   },
   "dependencies": {
     "@ensdomains/ensjs": "3.0.0-alpha.57",
-    "@tableland/sdk": "^4.2.2-pre.0",
-    "@tableland/sqlparser": "^1.0.6-pre.5",
+    "@tableland/sdk": "^4.2.2",
+    "@tableland/sqlparser": "^1.0.6",
     "cli-select-2": "^2.0.0",
     "cosmiconfig": "^8.0.0",
     "dotenv": "^16.0.3",

--- a/src/commands/shell.ts
+++ b/src/commands/shell.ts
@@ -56,19 +56,16 @@ async function fireFullQuery(
   tablelandConnection: Connections
 ) {
   try {
-    const { type } = await globalThis.sqlparser.normalize(statement);
     const { database, ens } = tablelandConnection;
-
     if (argv.enableEnsExperiment && ens) {
       statement = await ens.resolve(statement);
     }
 
-    let stmt;
-
+    const { type } = await globalThis.sqlparser.normalize(statement);
     if (type !== "read" && !(await confirmQuery())) return;
 
     try {
-      stmt = database.prepare(statement);
+      const stmt = database.prepare(statement);
       const response = await stmt.all();
 
       console.log(JSON.stringify(response.results));
@@ -138,7 +135,6 @@ async function shellYeah(
               break;
           }
         }
-
         if (state.trim().endsWith(";") || statement.trim().startsWith(".")) {
           break;
         }

--- a/src/lib/EnsResolver.ts
+++ b/src/lib/EnsResolver.ts
@@ -30,11 +30,8 @@ export default class EnsResolver {
   async resolveTable(tablename: string): Promise<string> {
     // strip the [] sql identifier escape characters at the start and
     // end, if they exist, then split on the "." separator
-    const [textRecord, ...domainArray] = tablename
-      .trim()
-      .replace(/^\[/, "")
-      .replace(/\]$/, "")
-      .split(".");
+    const [textRecord, ...domainArray] =
+      removeEscapeChars(tablename).split(".");
 
     const domain = domainArray.join(".");
     const address = await this.provider.getResolver(domain);
@@ -67,7 +64,7 @@ export default class EnsResolver {
 
     const resolvedTablenames = await Promise.all(
       tableNames.map(async (tableName) => {
-        tableName = tableName.trim().replace(/^\[/, "").replace(/\]$/, "");
+        tableName = removeEscapeChars(tableName);
         return [tableName, await this.resolveTable(tableName)];
       })
     );
@@ -81,4 +78,15 @@ export default class EnsResolver {
 
     return finalStatement;
   }
+}
+
+function removeEscapeChars(tableName: string): string {
+  return tableName
+    .trim()
+    .replace(/^\[/, "")
+    .replace(/\]$/, "")
+    .replace(/^`/, "")
+    .replace(/`$/, "")
+    .replace(/^"/, "")
+    .replace(/"$/, "");
 }

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -1,3 +1,4 @@
+import { equal } from "node:assert";
 import { describe, test, afterEach, before } from "mocha";
 import { spy, restore, assert, match } from "sinon";
 import yargs from "yargs/yargs";
@@ -74,7 +75,7 @@ describe("commands/controller", function () {
       "controller",
       "set",
       "invalid",
-      "",
+      "invalid",
       "--privateKey",
       privateKey,
       "--chain",
@@ -82,9 +83,11 @@ describe("commands/controller", function () {
     ])
       .command(mod)
       .parse();
-    assert.calledWith(
-      consoleError,
-      "error validating name: table name has wrong format: "
+
+    const value = consoleError.getCall(0).firstArg;
+    equal(
+      value.includes("error validating name: table name has wrong format: "),
+      true
     );
   });
 

--- a/test/info.test.ts
+++ b/test/info.test.ts
@@ -1,5 +1,6 @@
+import { equal } from "node:assert";
 import { describe, test, afterEach, before } from "mocha";
-import { spy, restore, assert, match } from "sinon";
+import { spy, restore, assert } from "sinon";
 import yargs from "yargs/yargs";
 import * as mod from "../src/commands/info.js";
 import { wait } from "../src/utils.js";
@@ -37,18 +38,13 @@ describe("commands/info", function () {
     const consoleLog = spy(console, "log");
     await yargs(["info", "healthbot_31337_1"]).command(mod).parse();
 
-    assert.calledWith(
-      consoleLog,
-      match(function (value: any) {
-        value = JSON.parse(value);
-        const { name, attributes, externalUrl } = value;
-        return (
-          name === "healthbot_31337_1" &&
-          externalUrl === "http://localhost:8080/chain/31337/tables/1" &&
-          Array.isArray(attributes)
-        );
-      }, "does not match")
-    );
+    const res = consoleLog.getCall(0).firstArg;
+    const value = JSON.parse(res);
+    const { name, attributes, externalUrl } = value;
+
+    equal(name, "healthbot_31337_1");
+    equal(externalUrl, "http://localhost:8080/api/v1/tables/31337/1");
+    equal(Array.isArray(attributes), true);
   });
 
   test("info throws with missing table", async function () {

--- a/test/shell.test.ts
+++ b/test/shell.test.ts
@@ -81,6 +81,78 @@ describe("commands/shell", function () {
     equal(call4.args[0], '[{"counter":1}]');
   });
 
+  test("ENS in shell with backtics", async function () {
+    const fullResolverStub = stub(
+      ethers.providers.JsonRpcProvider.prototype,
+      "getResolver"
+    ).callsFake(getResolverMock);
+
+    const consoleLog = spy(console, "log");
+    const stdin = mockStd.stdin();
+
+    setTimeout(() => {
+      stdin.send("select * from `foo.bar.eth`;\n").end();
+    }, 2000);
+
+    const [account] = getAccounts();
+    const privateKey = account.privateKey.slice(2);
+    await yargs([
+      "shell",
+      "--chain",
+      "local-tableland",
+      "--format",
+      "objects",
+      "--privateKey",
+      privateKey,
+      "--enableEnsExperiment",
+      "--ensProviderUrl",
+      "http://localhost:8545",
+    ])
+      .command(mod)
+      .parse();
+
+    fullResolverStub.reset();
+
+    const call4 = consoleLog.getCall(4);
+    equal(call4.args[0], '[{"counter":1}]');
+  });
+
+  test("ENS in shell with double quotes", async function () {
+    const fullResolverStub = stub(
+      ethers.providers.JsonRpcProvider.prototype,
+      "getResolver"
+    ).callsFake(getResolverMock);
+
+    const consoleLog = spy(console, "log");
+    const stdin = mockStd.stdin();
+
+    setTimeout(() => {
+      stdin.send(`select * from "foo.bar.eth";\n`).end();
+    }, 2000);
+
+    const [account] = getAccounts();
+    const privateKey = account.privateKey.slice(2);
+    await yargs([
+      "shell",
+      "--chain",
+      "local-tableland",
+      "--format",
+      "objects",
+      "--privateKey",
+      privateKey,
+      "--enableEnsExperiment",
+      "--ensProviderUrl",
+      "http://localhost:8545",
+    ])
+      .command(mod)
+      .parse();
+
+    fullResolverStub.reset();
+
+    const call4 = consoleLog.getCall(4);
+    equal(call4.args[0], '[{"counter":1}]');
+  });
+
   test("Shell Works with initial input", async function () {
     const consoleLog = spy(console, "log");
     const [account] = getAccounts();

--- a/test/shell.test.ts
+++ b/test/shell.test.ts
@@ -1,3 +1,4 @@
+import { equal } from "node:assert";
 import { describe, test } from "mocha";
 import { spy, assert, restore, match, stub } from "sinon";
 import yargs from "yargs/yargs";
@@ -45,7 +46,7 @@ describe("commands/shell", function () {
   });
 
   test("ENS in shell with single line", async function () {
-    const fullReolverStub = stub(
+    const fullResolverStub = stub(
       ethers.providers.JsonRpcProvider.prototype,
       "getResolver"
     ).callsFake(getResolverMock);
@@ -55,7 +56,7 @@ describe("commands/shell", function () {
 
     setTimeout(() => {
       stdin.send("select * from [foo.bar.eth];\n").end();
-    }, 1000);
+    }, 2000);
 
     const [account] = getAccounts();
     const privateKey = account.privateKey.slice(2);
@@ -74,9 +75,10 @@ describe("commands/shell", function () {
       .command(mod)
       .parse();
 
-    fullReolverStub.reset();
+    fullResolverStub.reset();
 
-    assert.match(consoleLog.getCall(4).args[0], '[{"counter":1}]');
+    const call4 = consoleLog.getCall(4);
+    equal(call4.args[0], '[{"counter":1}]');
   });
 
   test("Shell Works with initial input", async function () {

--- a/test/transfer.test.ts
+++ b/test/transfer.test.ts
@@ -1,5 +1,6 @@
+import { equal } from "node:assert";
 import { describe, test, afterEach, before } from "mocha";
-import { spy, restore, assert, match } from "sinon";
+import { spy, restore, assert } from "sinon";
 import yargs from "yargs/yargs";
 import { getAccounts, getDatabase } from "@tableland/local";
 import * as mod from "../src/commands/transfer.js";
@@ -109,16 +110,14 @@ describe("commands/transfer", function () {
       .command(mod)
       .parse();
 
-    assert.calledWith(
-      consoleLog,
-      match(function (value: any) {
-        value = JSON.parse(value);
-        const { to, from } = value;
-        return (
-          from === account1.address &&
-          to === helpers.getContractAddress("local-tableland")
-        );
-      }, "does not match")
+    const res = consoleLog.getCall(0).firstArg;
+    const value = JSON.parse(res);
+    const { to, from } = value;
+
+    equal(from.toLowerCase(), account1.address.toLowerCase());
+    equal(
+      to.toLowerCase(),
+      helpers.getContractAddress("local-tableland").toLowerCase()
     );
   });
 });


### PR DESCRIPTION
The recent changes to `@tableland/sqlparser` changed the way sql identifier escape sequences are handled, which  broke the ens feature.  
This PR upgrade the CLI's tableland dependencies and how the ens feature handles table name mapping.