### PR TITLE
Add an explanatory error message if there is no eth provider available

### DIFF
--- a/src/lib/EnsResolver.ts
+++ b/src/lib/EnsResolver.ts
@@ -40,7 +40,6 @@ export default class EnsResolver {
     const domain = domainArray.join(".");
     const address = await this.provider.getResolver(domain);
 
-    // TODO: mock `this.provider.getResolver` so address is undefined and we get coverage on the or clause
     return (await address?.getText(textRecord)) || tablename;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,8 +77,15 @@ export async function getWalletWithProvider({
   // Finally we use the default provider
   /* c8 ignore start */
   if (!provider) {
-    // This will be significantly rate limited, but we only need to run it once
-    provider = getDefaultProvider({ ...network, name: network.chainName });
+    try {
+      // This will be significantly rate limited, but we only need to run it once
+      provider = getDefaultProvider({ ...network, name: network.chainName });
+    } catch (err: any) {
+      // ethers.js only gives away default provider keys for some networks
+      throw new Error(
+        "no default provider is available for this network, you must provide one via flag (`-p` or `--providerUrl`)"
+      );
+    }
   }
 
   if (!provider) {


### PR DESCRIPTION
Fixes #305 
