### PR TITLE
remove experimental specifier resolution flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "coverage:report": "c8 report --reporter=html",
     "clean": "rm -rf dist",
     "build": "npx tsc && chmod +x dist/cli.js",
-    "tableland": "node --experimental-specifier-resolution=node ./dist/cli.js"
+    "tableland": "node ./dist/cli.js"
   },
   "license": "MIT AND Apache-2.0",
   "devDependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-specifier-resolution=node
+#!/usr/bin/env node
 
 import * as dotenv from "dotenv";
 import fetch, { Headers, Request, Response } from "node-fetch";


### PR DESCRIPTION
fixes #385

Ubuntu hangs forever if the `--experimental-specifier-resolution=node` flag is used.  Not sure why this is the case, but the flag is no longer needed for all of the current node.js LTS versions, so removing it both fixes the bug and cleans up the codebase.

[EDIT: anyone wanting to test directly can install version 5.2.3-pre.1]