### PR TITLE
Allow running acl statements

### DIFF
--- a/src/commands/write.ts
+++ b/src/commands/write.ts
@@ -67,7 +67,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
     statement = statement.replace(/\n/i, "").replace(/\r/, "");
     const normalized = await normalize(statement);
 
-    if (normalized.type !== "write") {
+    if (normalized.type !== "write" && normalized.type !== "acl") {
       logger.error("the `write` command can only accept write queries");
       return;
     }


### PR DESCRIPTION
fixes #386 

grant and revoke statements were not executing, this change enables that to happen.