### PR TITLE
fix: allow insert with subselect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@ensdomains/ensjs": "3.0.0-alpha.64",
-        "@tableland/sdk": "^4.4.0",
+        "@tableland/sdk": "^4.4.1",
         "@tableland/sqlparser": "^1.3.0",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^8.0.0",
@@ -1180,13 +1180,13 @@
       }
     },
     "node_modules/@tableland/sdk": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.4.0.tgz",
-      "integrity": "sha512-Wgzw5HrFhEithu3tl70HHMI0sk0YvsQXO22kL4jFAqm0sVQZt5q2/f6gBQhDokJF0kAxZOy5Ugdlyhef/SGNXA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.4.1.tgz",
+      "integrity": "sha512-UcV4D4GycfULhY5ol109/gAoeRyszeMQW5PBWekSVc7DdEEXZSQPvhP2TDzF3rvafT/YHhjYcOoi4yEFhZrnEw==",
       "dependencies": {
         "@async-generators/from-emitter": "^0.3.0",
         "@tableland/evm": "^4.3.0",
-        "@tableland/sqlparser": "^1.2.1",
+        "@tableland/sqlparser": "^1.3.0",
         "ethers": "^5.7.2"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@ensdomains/ensjs": "3.0.0-alpha.64",
-        "@tableland/sdk": "^4.3.2",
-        "@tableland/sqlparser": "^1.2.1",
+        "@tableland/sdk": "^4.4.0",
+        "@tableland/sqlparser": "^1.3.0",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^8.0.0",
         "dotenv": "^16.0.3",
@@ -65,6 +65,38 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz",
       "integrity": "sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ=="
+    },
+    "node_modules/@async-generators/from-emitter": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@async-generators/from-emitter/-/from-emitter-0.3.0.tgz",
+      "integrity": "sha512-9ne/GfJfbw77wuA08WtuNIvMhpDwAEPT/GX/Dn33y/Bu1zKqO0bOWmcWTpLiHrO2vedEbW0GihfkG7EINEghsA==",
+      "dependencies": {
+        "@async-generators/subject": "^0.4",
+        "@async-generators/terminator": "^0.4"
+      },
+      "engines": {
+        "node": ">=9.0.0"
+      }
+    },
+    "node_modules/@async-generators/subject": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@async-generators/subject/-/subject-0.4.0.tgz",
+      "integrity": "sha512-ydMe58ouMupnJlvBq6SaG6ranw1uX6rcAfAVE37oNJLen9RJ1+sY6yju8xp6en8RwWn3gBtAx03ot1Ycr3U0QQ==",
+      "dependencies": {
+        "@async-generators/terminator": "^0.4.0",
+        "events": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=9.0.0"
+      }
+    },
+    "node_modules/@async-generators/terminator": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@async-generators/terminator/-/terminator-0.4.0.tgz",
+      "integrity": "sha512-Kj08FqHgdx4QZ1mwJrlN3L2MWNNWHHWSQezfClxMUvGU1pYjoRa/4Yev1U/2Y71aqDDXEYC7pr13HNv7Un7Kog==",
+      "engines": {
+        "node": ">=9.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -1148,19 +1180,20 @@
       }
     },
     "node_modules/@tableland/sdk": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.3.2.tgz",
-      "integrity": "sha512-51tM7M/E2D9PvbbVf0274C+yYP1XrPUCVAB1REPVc87nfZRxf3ck203t740229qu1aDOp2daaCoI2kZRwbhkhA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.4.0.tgz",
+      "integrity": "sha512-Wgzw5HrFhEithu3tl70HHMI0sk0YvsQXO22kL4jFAqm0sVQZt5q2/f6gBQhDokJF0kAxZOy5Ugdlyhef/SGNXA==",
       "dependencies": {
+        "@async-generators/from-emitter": "^0.3.0",
         "@tableland/evm": "^4.3.0",
         "@tableland/sqlparser": "^1.2.1",
         "ethers": "^5.7.2"
       }
     },
     "node_modules/@tableland/sqlparser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.2.1.tgz",
-      "integrity": "sha512-M8lMrONHowCpGVT66rTnIrnLfuwCv1zJ5MBrvZsAFb1GtAYtj8WFxoKSl65loejksez/9ftTettLqAcrrNLqNQ=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.3.0.tgz",
+      "integrity": "sha512-5DddKKbxa3q1DcUBcf+D9bF0xYjoqWYRs8t941vZWDMRQjuHNPW7JjRA0W8zH+LDeKYqWmyJFsm1se8RxTcJPA=="
     },
     "node_modules/@tableland/validator": {
       "version": "1.6.3",
@@ -3136,6 +3169,14 @@
         "@ethersproject/wallet": "5.7.0",
         "@ethersproject/web": "5.7.1",
         "@ethersproject/wordlists": "5.7.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/evp_bytestokey": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@ensdomains/ensjs": "3.0.0-alpha.64",
-    "@tableland/sdk": "^4.4.0",
+    "@tableland/sdk": "^4.4.1",
     "@tableland/sqlparser": "^1.3.0",
     "cli-select-2": "^2.0.0",
     "cosmiconfig": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
   },
   "dependencies": {
     "@ensdomains/ensjs": "3.0.0-alpha.64",
-    "@tableland/sdk": "^4.3.2",
-    "@tableland/sqlparser": "^1.2.1",
+    "@tableland/sdk": "^4.4.0",
+    "@tableland/sqlparser": "^1.3.0",
     "cli-select-2": "^2.0.0",
     "cosmiconfig": "^8.0.0",
     "dotenv": "^16.0.3",

--- a/src/commands/write.ts
+++ b/src/commands/write.ts
@@ -97,12 +97,6 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
         normalized.statements.map(async function (stmt) {
           // re-normalize so we can be sure we've isolated each statement and it's tableId
           const norm = await normalize(stmt);
-          /* c8 ignore next 5 */
-          if (norm.tables.length > 1) {
-            throw new Error(
-              "cannot normalize if single query affects more then one table"
-            );
-          }
           const { tableId } = await globalThis.sqlparser.validateTableName(
             norm.tables[0]
           );
@@ -123,7 +117,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
     }, {} as any);
 
     const preparedStatements = Object.entries(statementsById).map(function ([
-      id,
+      _,
       stmt,
     ]) {
       /* c8 ignore next 1 */

--- a/test/write.test.ts
+++ b/test/write.test.ts
@@ -181,7 +181,7 @@ describe("commands/write", function () {
     );
   });
 
-  test("Write passes with local-tableland", async function () {
+  test("passes when writing with local-tableland", async function () {
     const [account] = accounts;
     const privateKey = account.privateKey.slice(2);
     const consoleLog = spy(logger, "log");
@@ -205,7 +205,7 @@ describe("commands/write", function () {
     equal(!link, true);
   });
 
-  test("Write to two tables passes", async function () {
+  test("passes when writing to two different tables", async function () {
     const account = accounts[1];
     const { meta: meta1 } = await db
       .prepare("create table multi_tbl_1 (a int, b text);")
@@ -347,7 +347,7 @@ describe("commands/write", function () {
     equal(resolverMock.calledOnce, true);
   });
 
-  test("Write works with GRANT statement", async function () {
+  test("passes with GRANT statement", async function () {
     const account1 = accounts[1];
     const account2 = accounts[2];
     const privateKey1 = account1.privateKey.slice(2);
@@ -405,13 +405,13 @@ describe("commands/write", function () {
     equal(results[0].a, 1);
   });
 
-  test("Write works with REVOKE statement", async function () {
+  test("passes with REVOKE statement", async function () {
     const account1 = accounts[1];
     const account2 = accounts[2];
     const privateKey1 = account1.privateKey.slice(2);
     const privateKey2 = account2.privateKey.slice(2);
 
-    // db is configged with account 1
+    // db is configured with account 1
     const { meta } = await db
       .prepare("CREATE TABLE test_revoke (a int);")
       .all();
@@ -474,5 +474,64 @@ describe("commands/write", function () {
       .parse();
 
     match(consoleError.getCall(0).firstArg, /not enough privileges/);
+  });
+
+  test("passes with insert and subselect", async function () {
+    const account = accounts[1];
+    // create a "main" (mutable target) table and an "admin" (subselect target) table
+    const [batchCreate] = await db.batch([
+      db.prepare(`CREATE TABLE main (id INTEGER PRIMARY KEY, data TEXT);`),
+      db.prepare(`CREATE TABLE admin (id INTEGER PRIMARy KEY, address TEXT);`),
+    ]);
+    const response = await batchCreate.meta.txn?.wait();
+    const names = response?.names ?? [];
+    const tableToMutate = names[0];
+    const tableToSubselect = names[1];
+
+    // seed the target subselect table with data
+    const privateKey = account.privateKey.slice(2);
+    const consoleLog = spy(logger, "log");
+    await yargs([
+      "write",
+      `INSERT INTO ${tableToSubselect} (address) VALUES ('${account.address}');`,
+      "--chain",
+      "local-tableland",
+      "--privateKey",
+      privateKey,
+    ])
+      .command(mod)
+      .parse();
+    let res = consoleLog.getCall(0).firstArg;
+    let value = JSON.parse(res);
+    let { transactionHash, link } = value.meta?.txn;
+    equal(typeof transactionHash, "string");
+    equal(transactionHash.startsWith("0x"), true);
+    equal(!link, true);
+
+    // insert into the "main" table using a subselect from the "admin" table
+    const data = "test";
+    await yargs([
+      "write",
+      `INSERT INTO ${tableToMutate} (data) select '${data}' from ${tableToSubselect} where address = '${account.address}';`,
+      "--chain",
+      "local-tableland",
+      "--privateKey",
+      privateKey,
+    ])
+      .command(mod)
+      .parse();
+    res = consoleLog.getCall(0).firstArg;
+    value = JSON.parse(res);
+    ({ transactionHash, link } = value.meta?.txn);
+    equal(typeof transactionHash, "string");
+    equal(transactionHash.startsWith("0x"), true);
+    equal(!link, true);
+
+    // verify the data was inserted, including the auto-incremented `id`
+    const { results } = (await db
+      .prepare(`select * from ${tableToMutate};`)
+      .run()) as any;
+    equal(results[0].id, 1);
+    equal(results[0].data, data);
   });
 });


### PR DESCRIPTION
## Summary

The fix is handled in the SDK to allow an INSERT with a subselect statement. There is slight logic _removal_ here, which was previously throwing an error due to the CLI thinking the mutating query is affecting more than one table. Closes #392.

## Details

There is an open PR in the SDK ([here](https://github.com/tablelandnetwork/js-tableland/pull/562)) that will resolve the issue, which was due to the CLI's usage of the `batch` method that wasn't allowing for mutating queries with subselects. That PR must be merged first.

Additionally, the CLI had the following code, which was deemed unnecessary as the SDK `batch` method will throw the error `parsing query: queries are referencing two distinct tables`; thus, this is no longer needed:

```ts
if (norm.tables.length > 1) {
  throw new Error(
    "cannot normalize if single query affects more then one table"
  );
}
```

Note: if you pass a single statement with multiple tables (e.g., `INSERT INTO table1 ...; INSERT INTO table2 ...`), the CLI actually splits these into separate runnables. This is noted because it's somewhat related to logic removed above but, again, the SDK should bubble up the error noted above.

## How it was tested

Added a test while setting up a symlink to the SDK PR noted above: `passes with insert and subselect`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
