### PR TITLE
fix: remove duplicative error logging

### DIFF
--- a/src/commands/shell.ts
+++ b/src/commands/shell.ts
@@ -78,10 +78,9 @@ async function fireFullQuery(
         break;
       default:
     }
-    /* c8 ignore next 3 */
+    /* c8 ignore next 2 */
   } catch (err: any) {
     logger.error(err?.cause?.message || err?.message);
-    logger.error(err);
   }
 }
 


### PR DESCRIPTION
## Summary

There was extra error logging being shown in the `shell`, causing the verbose error to show in the shell unexpectedly.

Edit: maybe this is intended? I feel like it clouds my shell terminal with these errors, making it hard to read my shell's history, but for comparison, `npx hardhat console` _does_ log the full error trace.

## Details

The change:
```diff
logger.error(err?.cause?.message || err?.message);
- logger.error(err);
```

For example, if you try to create a table with erroneous syntax, you'd expect only the first line of this error (the message) to be logged, not the full error itself.
```
error parsing statement: syntax error at position 28 near ';'
Error: error parsing statement: syntax error at position 28 near ';'
    at syscall/js.valueNew (/Users/dtb/tbl/js-tableland-cli/node_modules/@tableland/sqlparser/cjs/out.js:435:44)
    at wasm://wasm/001dec26:wasm-function[257]:0x2a075
    at wasm://wasm/001dec26:wasm-function[433]:0x5f222
    at wasm://wasm/001dec26:wasm-function[134]:0x1146e
    at wasm://wasm/001dec26:wasm-function[440]:0x6088a
    at global.Go._resume (/Users/dtb/tbl/js-tableland-cli/node_modules/@tableland/sqlparser/cjs/out.js:534:26)
    at /Users/dtb/tbl/js-tableland-cli/node_modules/@tableland/sqlparser/cjs/out.js:544:13
    at new Promise (<anonymous>)
    at syscall/js.valueNew (/Users/dtb/tbl/js-tableland-cli/node_modules/@tableland/sqlparser/cjs/out.js:435:44)
    at wasm://wasm/001dec26:wasm-function[257]:0x2a075
    at wasm://wasm/001dec26:wasm-function[223]:0x25491
    at wasm://wasm/001dec26:wasm-function[135]:0x11a56
    at wasm://wasm/001dec26:wasm-function[134]:0x1146e
    at wasm://wasm/001dec26:wasm-function[440]:0x608b9
    at global.Go._resume (/Users/dtb/tbl/js-tableland-cli/node_modules/@tableland/sqlparser/cjs/out.js:534:26)
    at Object.normalize (/Users/dtb/tbl/js-tableland-cli/node_modules/@tableland/sqlparser/cjs/out.js:544:13)
    at fireFullQuery (file:///Users/dtb/tbl/js-tableland-cli/src/commands/shell.ts:65:49)
    at shellYeah (file:///Users/dtb/tbl/js-tableland-cli/src/commands/shell.ts:140:15)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Object.handler (file:///Users/dtb/tbl/js-tableland-cli/src/commands/shell.ts:192:5)
```

## How it was tested

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
