### PR TITLE
feat: table aliases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 TBL_PRIVATE_KEY=fillme
 TBL_CHAIN=fillme
 TBL_PROVIDER_URL=fillme
+TBL_ALIASES=fillme

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 .env
 .DS_Store
 .tableland*
+tableland.aliases.json
 coverage/

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Options:
       --version      Show version number                               [boolean]
   -k, --privateKey   Private key string                                 [string]
   -c, --chain        The EVM chain to target      [string] [default: "maticmum"]
-  -p, --providerUrl  JSON RPC API provider URL. (e.g., https://eth-rinkeby.alche
+  -p, --providerUrl  JSON RPC API provider URL. (e.g., https://eth-sepolia.alche
                      myapi.io/v2/123abc123a...)                         [string]
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,7 +59,7 @@ const _argv = yargs(hideBin(process.argv))
   .env("TBL")
   .config(config?.config)
   // the help and version options are internal to yargs, hence they are
-  // at the top of the help message no matter what order we specifiy
+  // at the top of the help message no matter what order we specify
   .option("help", {
     alias: "h",
   })
@@ -91,7 +91,7 @@ const _argv = yargs(hideBin(process.argv))
     alias: "p",
     type: "string",
     description:
-      "JSON RPC API provider URL. (e.g., https://eth-rinkeby.alchemyapi.io/v2/123abc123a...)",
+      "JSON RPC API provider URL (e.g., https://eth-sepolia.g.alchemy.com/v2/123abc123a...)",
   })
   .demandCommand(1, "")
   .strict().argv;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,7 @@ export interface GlobalOptions {
   verbose: boolean;
   ensProviderUrl?: string;
   enableEnsExperiment?: boolean;
+  aliases?: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -92,6 +93,12 @@ const _argv = yargs(hideBin(process.argv))
     type: "string",
     description:
       "JSON RPC API provider URL (e.g., https://eth-sepolia.g.alchemy.com/v2/123abc123a...)",
+  })
+  .option("aliases", {
+    alias: "a",
+    type: "string",
+    description:
+      "Path to table aliases JSON file (e.g., ./tableland.aliases.json)",
   })
   .demandCommand(1, "")
   .strict().argv;

--- a/src/commands/controller.ts
+++ b/src/commands/controller.ts
@@ -3,7 +3,7 @@ import type { Arguments, CommandBuilder } from "yargs";
 import { Registry } from "@tableland/sdk";
 import { init } from "@tableland/sqlparser";
 import {
-  getTableNameFromAlias,
+  getTableNameWithAlias,
   getWalletWithProvider,
   getLink,
   logger,
@@ -47,7 +47,7 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
 
           // Check if the passed `name` is a table alias
           if (argv.aliases != null)
-            name = await getTableNameFromAlias(argv.aliases, name);
+            name = await getTableNameWithAlias(argv.aliases, name);
 
           const reg = new Registry({ signer });
           const res = await reg.getController(name);
@@ -87,7 +87,7 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
 
           // Check if the passed `name` is a table alias
           if (argv.aliases != null)
-            name = await getTableNameFromAlias(argv.aliases, name);
+            name = await getTableNameWithAlias(argv.aliases, name);
 
           const reg = new Registry({ signer });
           const res = await reg.setController({ tableName: name, controller });
@@ -124,7 +124,7 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
 
           // Check if the passed `name` is a table alias
           if (argv.aliases != null)
-            name = await getTableNameFromAlias(argv.aliases, name);
+            name = await getTableNameWithAlias(argv.aliases, name);
 
           const reg = new Registry({ signer });
           const res = await reg.lockController(name);

--- a/src/commands/controller.ts
+++ b/src/commands/controller.ts
@@ -34,7 +34,7 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
         }) as yargs.Argv<Options>,
       async (argv) => {
         await init();
-        const { privateKey, providerUrl, aliases } = argv;
+        const { privateKey, providerUrl } = argv;
         const chain = getChainName(argv.chain);
         let { name } = argv;
 
@@ -46,7 +46,8 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
           });
 
           // Check if the passed `name` is a table alias
-          if (aliases) name = await getTableNameFromAlias(aliases, name);
+          if (argv.aliases != null)
+            name = await getTableNameFromAlias(argv.aliases, name);
 
           const reg = new Registry({ signer });
           const res = await reg.getController(name);
@@ -73,7 +74,7 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
           }) as yargs.Argv<Options>,
       async (argv) => {
         await init();
-        const { controller, privateKey, providerUrl, aliases } = argv;
+        const { controller, privateKey, providerUrl } = argv;
         const chain = getChainName(argv.chain);
         let { name } = argv;
 
@@ -85,7 +86,8 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
           });
 
           // Check if the passed `name` is a table alias
-          if (aliases) name = await getTableNameFromAlias(aliases, name);
+          if (argv.aliases != null)
+            name = await getTableNameFromAlias(argv.aliases, name);
 
           const reg = new Registry({ signer });
           const res = await reg.setController({ tableName: name, controller });
@@ -109,7 +111,7 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
         }) as yargs.Argv<Options>,
       async (argv) => {
         await init();
-        const { privateKey, providerUrl, aliases } = argv;
+        const { privateKey, providerUrl } = argv;
         const chain = getChainName(argv.chain);
         let { name } = argv;
 
@@ -121,7 +123,8 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
           });
 
           // Check if the passed `name` is a table alias
-          if (aliases) name = await getTableNameFromAlias(aliases, name);
+          if (argv.aliases != null)
+            name = await getTableNameFromAlias(argv.aliases, name);
 
           const reg = new Registry({ signer });
           const res = await reg.lockController(name);

--- a/src/commands/controller.ts
+++ b/src/commands/controller.ts
@@ -3,11 +3,11 @@ import type { Arguments, CommandBuilder } from "yargs";
 import { Registry } from "@tableland/sdk";
 import { init } from "@tableland/sqlparser";
 import {
+  getTableNameFromAlias,
   getWalletWithProvider,
   getLink,
   logger,
   getChainName,
-  jsonFileAliases,
 } from "../utils.js";
 import { type GlobalOptions } from "../cli.js";
 
@@ -44,23 +44,11 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
             chain,
             providerUrl,
           });
-          const reg = new Registry({ signer });
 
-          // Check if the passed `name` is valid, otherwise, if it's a table alias
-          try {
-            await globalThis.sqlparser.validateTableName(name);
-          } catch (err: any) {
-            if (aliases) {
-              const nameMap = await jsonFileAliases(aliases).read();
-              name = nameMap[name];
-            }
-            if (!name) {
-              logger.error(
-                "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
-              );
-              return;
-            }
-          }
+          // Check if the passed `name` is a table alias
+          if (aliases) name = await getTableNameFromAlias(aliases, name);
+
+          const reg = new Registry({ signer });
           const res = await reg.getController(name);
 
           logger.log(res);
@@ -96,22 +84,10 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
             providerUrl,
           });
 
+          // Check if the passed `name` is a table alias
+          if (aliases) name = await getTableNameFromAlias(aliases, name);
+
           const reg = new Registry({ signer });
-          // Check if the passed `name` is valid, otherwise, if it's a table alias
-          try {
-            await globalThis.sqlparser.validateTableName(name);
-          } catch (err: any) {
-            if (aliases) {
-              const nameMap = await jsonFileAliases(aliases).read();
-              name = nameMap[name];
-            }
-            if (!name) {
-              logger.error(
-                "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
-              );
-              return;
-            }
-          }
           const res = await reg.setController({ tableName: name, controller });
 
           const link = getLink(chain, res.hash);
@@ -144,22 +120,10 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
             providerUrl,
           });
 
+          // Check if the passed `name` is a table alias
+          if (aliases) name = await getTableNameFromAlias(aliases, name);
+
           const reg = new Registry({ signer });
-          // Check if the passed `name` is valid, otherwise, if it's a table alias
-          try {
-            await globalThis.sqlparser.validateTableName(name);
-          } catch (err: any) {
-            if (aliases) {
-              const nameMap = await jsonFileAliases(aliases).read();
-              name = nameMap[name];
-            }
-            if (!name) {
-              logger.error(
-                "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
-              );
-              return;
-            }
-          }
           const res = await reg.lockController(name);
 
           const link = getLink(chain, res.hash);

--- a/src/commands/controller.ts
+++ b/src/commands/controller.ts
@@ -1,6 +1,7 @@
 import type yargs from "yargs";
 import type { Arguments, CommandBuilder } from "yargs";
 import { Registry } from "@tableland/sdk";
+import { init } from "@tableland/sqlparser";
 import {
   getWalletWithProvider,
   getLink,
@@ -9,7 +10,6 @@ import {
   jsonFileAliases,
 } from "../utils.js";
 import { type GlobalOptions } from "../cli.js";
-import { setupCommand } from "../lib/commandSetup.js";
 
 export interface Options extends GlobalOptions {
   name: string;
@@ -33,7 +33,7 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
           description: "The target table name (or alias, if enabled)",
         }) as yargs.Argv<Options>,
       async (argv) => {
-        const { normalize } = await setupCommand(argv);
+        await init();
         const { privateKey, providerUrl, aliases } = argv;
         const chain = getChainName(argv.chain);
         let { name } = argv;
@@ -48,7 +48,7 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
 
           // Check if the passed `name` is valid, otherwise, if it's a table alias
           try {
-            await normalize(name);
+            await globalThis.sqlparser.validateTableName(name);
           } catch (err: any) {
             if (aliases) {
               const nameMap = await jsonFileAliases(aliases).read();
@@ -84,7 +84,7 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
             description: "The target table name (or alias, if enabled)",
           }) as yargs.Argv<Options>,
       async (argv) => {
-        const { normalize } = await setupCommand(argv);
+        await init();
         const { controller, privateKey, providerUrl, aliases } = argv;
         const chain = getChainName(argv.chain);
         let { name } = argv;
@@ -99,7 +99,7 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
           const reg = new Registry({ signer });
           // Check if the passed `name` is valid, otherwise, if it's a table alias
           try {
-            await normalize(name);
+            await globalThis.sqlparser.validateTableName(name);
           } catch (err: any) {
             if (aliases) {
               const nameMap = await jsonFileAliases(aliases).read();
@@ -132,7 +132,7 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
           description: "The target table name (or alias, if enabled)",
         }) as yargs.Argv<Options>,
       async (argv) => {
-        const { normalize } = await setupCommand(argv);
+        await init();
         const { privateKey, providerUrl, aliases } = argv;
         const chain = getChainName(argv.chain);
         let { name } = argv;
@@ -147,7 +147,7 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
           const reg = new Registry({ signer });
           // Check if the passed `name` is valid, otherwise, if it's a table alias
           try {
-            await normalize(name);
+            await globalThis.sqlparser.validateTableName(name);
           } catch (err: any) {
             if (aliases) {
               const nameMap = await jsonFileAliases(aliases).read();

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -43,15 +43,15 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
           ));
         } catch (err: any) {
           // Throw only if ENS isn't enabled, which is checked next
-          if (!(enableEnsExperiment && ensProviderUrl))
+          if (!(enableEnsExperiment && ensProviderUrl)) {
             logger.error("invalid table alias, table name not found");
-          return;
+            return;
+          }
         }
       }
       // We'll throw later if `chainId` or `tableId` are undefined
     }
     // If ENS is enabled, perform a last attempt on validation
-    /* c8 ignore next 11 */
     if (enableEnsExperiment && ensProviderUrl) {
       const { ens } = await setupCommand({
         ...argv,

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -3,7 +3,7 @@ import type { Arguments, CommandBuilder } from "yargs";
 import { init } from "@tableland/sqlparser";
 import { type GlobalOptions } from "../cli.js";
 import { setupCommand } from "../lib/commandSetup.js";
-import { getTableNameFromAlias, logger } from "../utils.js";
+import { getTableNameWithAlias, logger } from "../utils.js";
 
 export interface Options extends GlobalOptions {
   name: string;
@@ -27,7 +27,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
 
     // Check if the passed `name` is a table alias
     if (argv.aliases != null)
-      name = await getTableNameFromAlias(argv.aliases, name);
+      name = await getTableNameWithAlias(argv.aliases, name);
     // Check if the passed `name` uses ENS
     // Note: duplicative `setupCommand` calls will occur with ENS, but this is
     // required to properly parse the chainId from the table name

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -26,7 +26,8 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
     let { name } = argv;
 
     // Check if the passed `name` is a table alias
-    if (argv.aliases) name = await getTableNameFromAlias(argv.aliases, name);
+    if (argv.aliases != null)
+      name = await getTableNameFromAlias(argv.aliases, name);
     // Check if the passed `name` uses ENS
     // Note: duplicative `setupCommand` calls will occur with ENS, but this is
     // required to properly parse the chainId from the table name
@@ -34,7 +35,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
       const { ens } = await setupCommand({
         ...argv,
       });
-      if (ens) name = await ens.resolveTable(name);
+      if (ens != null) name = await ens.resolveTable(name);
     }
 
     const [tableId, chainId] = name.split("_").reverse();

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,8 +1,10 @@
 import type yargs from "yargs";
 import type { Arguments, CommandBuilder } from "yargs";
+import { helpers } from "@tableland/sdk";
+import { init } from "@tableland/sqlparser";
 import { type GlobalOptions } from "../cli.js";
 import { setupCommand } from "../lib/commandSetup.js";
-import { logger } from "../utils.js";
+import { jsonFileAliases, logger } from "../utils.js";
 
 export interface Options extends GlobalOptions {
   name: string;
@@ -20,32 +22,69 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
   }) as yargs.Argv<Options>;
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
+  await init();
   try {
-    let { name } = argv;
-    const [tableId, chainId] = name.split("_").reverse();
+    const { name, aliases, enableEnsExperiment, ensProviderUrl } = argv;
 
-    const parts = name.split("_");
+    let chainId, tableId;
+    // Check if the passed `name` is valid, otherwise, if it's a table alias,
+    // making sure standard table names take precedence
+    try {
+      ({ chainId, tableId } = await globalThis.sqlparser.validateTableName(
+        name
+      ));
+    } catch (err: any) {
+      if (aliases) {
+        try {
+          const nameMap = await jsonFileAliases(aliases).read();
+          const nameFromAlias = nameMap[name];
+          ({ chainId, tableId } = await globalThis.sqlparser.validateTableName(
+            nameFromAlias
+          ));
+        } catch (err: any) {
+          // Throw only if ENS isn't enabled, which is checked next
+          if (!(enableEnsExperiment && ensProviderUrl))
+            logger.error("invalid table alias, table name not found");
+          return;
+        }
+      }
+      // We'll throw later if `chainId` or `tableId` are undefined
+    }
+    // If ENS is enabled, perform a last attempt on validation
+    /* c8 ignore next 11 */
+    if (enableEnsExperiment && ensProviderUrl) {
+      const { ens } = await setupCommand({
+        ...argv,
+      });
+      try {
+        const nameFromEns = await ens?.resolveTable(name);
+        if (nameFromEns)
+          ({ chainId, tableId } = await globalThis.sqlparser.validateTableName(
+            nameFromEns
+          ));
+      } catch (err: any) {
+        logger.error("invalid ENS namespace, table record not found");
+        return;
+      }
+    }
 
-    if (parts.length < 3 && argv.enableEnsExperiment == null) {
+    // The "standard" table name was passed and is invalid if these are undefined
+    if (tableId === undefined || chainId === undefined) {
       logger.error(
         "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
       );
       return;
     }
 
-    const { ens, validator } = await setupCommand({
+    // Note: should `setupCommand` be used again, or instantiate a validator directly?
+    const { validator } = await setupCommand({
       ...argv,
-      chain: parseInt(chainId) as any,
+      chain: helpers.getChainInfo(chainId).chainName,
     });
 
-    /* c8 ignore next 3 */
-    if (argv.enableEnsExperiment != null && ens != null) {
-      name = await ens.resolveTable(name);
-    }
-
     const res = await validator.getTableById({
-      tableId,
-      chainId: parseInt(chainId),
+      tableId: tableId.toString(),
+      chainId,
     });
     logger.log(JSON.stringify(res));
     /* c8 ignore next 7 */

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,10 +1,15 @@
 import { resolve, dirname } from "path";
-import { mkdirSync, createWriteStream, type WriteStream } from "fs";
+import {
+  mkdirSync,
+  createWriteStream,
+  type WriteStream,
+  writeFileSync,
+} from "fs";
 import type yargs from "yargs";
 import type { Arguments, CommandBuilder } from "yargs";
 import yaml from "js-yaml";
 import inquirer from "inquirer";
-import { getChains, logger } from "../utils.js";
+import { getChains, logger, checkPath } from "../utils.js";
 import { type GlobalOptions } from "../cli.js";
 
 export interface Options extends GlobalOptions {
@@ -82,6 +87,12 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
           return resolve(`.${moduleName}rc.${answers.format as string}`);
         },
       },
+      {
+        type: "input",
+        name: "aliases",
+        message:
+          "Enter file path to existing table aliases file, or directory path to create a new one (optional)",
+      },
     ];
 
     // Extract path and format as we don't include them in the config file
@@ -92,14 +103,34 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   } else {
     output = { ...defaults, ...answers };
   }
-  const { path, format, ...rest } = output;
-  const filePath = resolve(
-    typeof path === "string" ? path : `.${moduleName}rc`
-  );
+  // Create the config file
+  const { path, format, aliases, ...rest } = output;
+  const configFilePath = resolve(path || `.${moduleName}rc`);
+  // Make sure the table aliases file or provided directory exists
+  if (aliases) {
+    const type = await checkPath(aliases);
+    switch (type) {
+      case "file":
+        rest.aliases = resolve(aliases);
+        break;
+      case "dir": {
+        const aliasesFilePath = resolve(aliases, "tableland.aliases.json");
+        writeFileSync(aliasesFilePath, "{}");
+        rest.aliases = aliasesFilePath;
+        break;
+      }
+      default:
+        // If the paths were invalid, log an error and exit early
+        logger.error(
+          `Failed: table aliases JSON file or directory path does not exist, please enter a valid path`
+        );
+        return;
+    }
+  }
   let stream = process.stdout as unknown as WriteStream;
   if (path !== ".") {
-    mkdirSync(dirname(filePath), { recursive: true });
-    stream = createWriteStream(filePath, "utf-8");
+    mkdirSync(dirname(configFilePath), { recursive: true });
+    stream = createWriteStream(configFilePath, "utf-8") as WriteStream;
   }
   try {
     switch (format) {
@@ -113,7 +144,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
         break;
     }
     if (path !== ".") {
-      logger.log(`Config created at ${filePath}`);
+      logger.log(`Config created at ${configFilePath}`);
     }
   } catch (err: any) {
     logger.error(err.message);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -105,9 +105,9 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   }
   // Create the config file
   const { path, format, aliases, ...rest } = output;
-  const configFilePath = resolve(path || `.${moduleName}rc`);
+  const configFilePath = resolve(path ?? `.${moduleName}rc`);
   // Make sure the table aliases file or provided directory exists
-  if (aliases) {
+  if (aliases != null) {
     try {
       const type = checkAliasesPath(aliases);
       if (type === "file") {
@@ -126,7 +126,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   let stream = process.stdout as unknown as WriteStream;
   if (path !== ".") {
     mkdirSync(dirname(configFilePath), { recursive: true });
-    stream = createWriteStream(configFilePath, "utf-8") as WriteStream;
+    stream = createWriteStream(configFilePath, "utf-8");
   }
   try {
     switch (format) {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -109,13 +109,13 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   // Make sure the table aliases file or provided directory exists
   if (aliases) {
     try {
-      const type = await checkAliasesPath(aliases);
+      const type = checkAliasesPath(aliases);
       if (type === "file") {
         rest.aliases = resolve(aliases);
       }
       if (type === "dir") {
         const aliasesFilePath = resolve(aliases, "tableland.aliases.json");
-        writeFileSync(aliasesFilePath, "{}");
+        writeFileSync(aliasesFilePath, JSON.stringify({}));
         rest.aliases = aliasesFilePath;
       }
     } catch (err: any) {

--- a/src/commands/namespace.ts
+++ b/src/commands/namespace.ts
@@ -48,10 +48,10 @@ async function setHandler(
       const valueRegex = /^[a-zA-Z_][a-zA-Z0-9_]*_[0-9]+_[0-9]+$/;
 
       if (keyRegex.exec(key) === null) {
-        throw new Error("Only letters or underscores in key name");
+        throw new Error("only letters or underscores in key name");
       }
       if (valueRegex.exec(value) === null) {
-        throw new Error("Tablename is invalid");
+        throw new Error("table name is invalid");
       }
       return {
         key,
@@ -84,7 +84,7 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
   yargs
     .command(
       "get <record>",
-      "Pass in a record to find it's table name",
+      "Pass in a record to find its table name",
       (yargs) =>
         yargs.positional("record", {
           type: "string",

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -1,8 +1,10 @@
 import type yargs from "yargs";
 import type { Arguments, CommandBuilder } from "yargs";
+import { helpers } from "@tableland/sdk";
+import { init } from "@tableland/sqlparser";
 import { type GlobalOptions } from "../cli.js";
 import { setupCommand } from "../lib/commandSetup.js";
-import { logger } from "../utils.js";
+import { jsonFileAliases, logger } from "../utils.js";
 
 export interface Options extends GlobalOptions {
   name: string;
@@ -21,12 +23,53 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   try {
-    const { name } = argv;
-    const [tableId, chainId] = name.split("_").reverse();
+    await init();
+    const { name, aliases, enableEnsExperiment, ensProviderUrl } = argv;
 
-    const parts = name.split("_");
+    let chainId, tableId;
+    // Check if the passed `name` is valid, otherwise, if it's a table alias,
+    // making sure standard table names take precedence
+    try {
+      ({ chainId, tableId } = await globalThis.sqlparser.validateTableName(
+        name
+      ));
+    } catch (err: any) {
+      if (aliases) {
+        try {
+          const nameMap = await jsonFileAliases(aliases).read();
+          const nameFromAlias = nameMap[name];
+          ({ chainId, tableId } = await globalThis.sqlparser.validateTableName(
+            nameFromAlias
+          ));
+        } catch (err: any) {
+          // Throw only if ENS isn't enabled, which is checked next
+          if (!(enableEnsExperiment && ensProviderUrl))
+            logger.error("invalid table alias, table name not found");
+          return;
+        }
+      }
+      // We'll throw later if `chainId` or `tableId` are undefined
+    }
+    // If ENS is enabled, perform a last attempt on validation
+    /* c8 ignore next 11 */
+    if (enableEnsExperiment && ensProviderUrl) {
+      const { ens } = await setupCommand({
+        ...argv,
+      });
+      try {
+        const nameFromEns = await ens?.resolveTable(name);
+        if (nameFromEns)
+          ({ chainId, tableId } = await globalThis.sqlparser.validateTableName(
+            nameFromEns
+          ));
+      } catch (err: any) {
+        logger.error("invalid ENS namespace, table record not found");
+        return;
+      }
+    }
 
-    if (parts.length < 3 && argv.enableEnsExperiment == null) {
+    // The "standard" table name was passed and is invalid if these are undefined
+    if (tableId === undefined || chainId === undefined) {
       logger.error(
         "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
       );
@@ -35,12 +78,12 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
 
     const { validator } = await setupCommand({
       ...argv,
-      chain: parseInt(chainId) as any,
+      chain: helpers.getChainInfo(chainId).chainName,
     });
 
     const res = await validator.getTableById({
-      tableId,
-      chainId: parseInt(chainId),
+      tableId: tableId.toString(),
+      chainId,
     });
     logger.log(JSON.stringify(res.schema));
     /* c8 ignore next 3 */

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -1,10 +1,9 @@
 import type yargs from "yargs";
 import type { Arguments, CommandBuilder } from "yargs";
-import { helpers } from "@tableland/sdk";
 import { init } from "@tableland/sqlparser";
 import { type GlobalOptions } from "../cli.js";
 import { setupCommand } from "../lib/commandSetup.js";
-import { jsonFileAliases, logger } from "../utils.js";
+import { logger, getTableNameFromAlias } from "../utils.js";
 
 export interface Options extends GlobalOptions {
   name: string;
@@ -24,53 +23,24 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   try {
     await init();
-    const { name, aliases, enableEnsExperiment, ensProviderUrl } = argv;
+    let { name } = argv;
 
-    let chainId, tableId;
-    // Check if the passed `name` is valid, otherwise, if it's a table alias,
-    // making sure standard table names take precedence
-    try {
-      ({ chainId, tableId } = await globalThis.sqlparser.validateTableName(
-        name
-      ));
-    } catch (err: any) {
-      if (aliases) {
-        try {
-          const nameMap = await jsonFileAliases(aliases).read();
-          const nameFromAlias = nameMap[name];
-          ({ chainId, tableId } = await globalThis.sqlparser.validateTableName(
-            nameFromAlias
-          ));
-        } catch (err: any) {
-          // Throw only if ENS isn't enabled, which is checked next
-          if (!(enableEnsExperiment && ensProviderUrl)) {
-            logger.error("invalid table alias, table name not found");
-            return;
-          }
-        }
-      }
-      // We'll throw later if `chainId` or `tableId` are undefined
-    }
-    // If ENS is enabled, perform a last attempt on validation
-    /* c8 ignore next 11 */
-    if (enableEnsExperiment && ensProviderUrl) {
+    // Check if the passed `name` is a table alias
+    if (argv.aliases) name = await getTableNameFromAlias(argv.aliases, name);
+    // Check if the passed `name` uses ENS
+    // Note: duplicative `setupCommand` calls will occur with ENS, but this is
+    // required to properly parse the chainId from the table name
+    if (argv.enableEnsExperiment != null && argv.ensProviderUrl != null) {
       const { ens } = await setupCommand({
         ...argv,
       });
-      try {
-        const nameFromEns = await ens?.resolveTable(name);
-        if (nameFromEns)
-          ({ chainId, tableId } = await globalThis.sqlparser.validateTableName(
-            nameFromEns
-          ));
-      } catch (err: any) {
-        logger.error("invalid ENS namespace, table record not found");
-        return;
-      }
+      if (ens) name = await ens.resolveTable(name);
     }
 
-    // The "standard" table name was passed and is invalid if these are undefined
-    if (tableId === undefined || chainId === undefined) {
+    const [tableId, chainId] = name.split("_").reverse();
+    const parts = name.split("_");
+
+    if (parts.length < 3 && argv.enableEnsExperiment == null) {
       logger.error(
         "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
       );
@@ -79,12 +49,12 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
 
     const { validator } = await setupCommand({
       ...argv,
-      chain: helpers.getChainInfo(chainId).chainName,
+      chain: parseInt(chainId) as any,
     });
 
     const res = await validator.getTableById({
       tableId: tableId.toString(),
-      chainId,
+      chainId: parseInt(chainId),
     });
     logger.log(JSON.stringify(res.schema));
     /* c8 ignore next 3 */

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -43,9 +43,10 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
           ));
         } catch (err: any) {
           // Throw only if ENS isn't enabled, which is checked next
-          if (!(enableEnsExperiment && ensProviderUrl))
+          if (!(enableEnsExperiment && ensProviderUrl)) {
             logger.error("invalid table alias, table name not found");
-          return;
+            return;
+          }
         }
       }
       // We'll throw later if `chainId` or `tableId` are undefined

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -26,7 +26,8 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
     let { name } = argv;
 
     // Check if the passed `name` is a table alias
-    if (argv.aliases) name = await getTableNameFromAlias(argv.aliases, name);
+    if (argv.aliases != null)
+      name = await getTableNameFromAlias(argv.aliases, name);
     // Check if the passed `name` uses ENS
     // Note: duplicative `setupCommand` calls will occur with ENS, but this is
     // required to properly parse the chainId from the table name
@@ -34,7 +35,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
       const { ens } = await setupCommand({
         ...argv,
       });
-      if (ens) name = await ens.resolveTable(name);
+      if (ens != null) name = await ens.resolveTable(name);
     }
 
     const [tableId, chainId] = name.split("_").reverse();

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -3,7 +3,7 @@ import type { Arguments, CommandBuilder } from "yargs";
 import { init } from "@tableland/sqlparser";
 import { type GlobalOptions } from "../cli.js";
 import { setupCommand } from "../lib/commandSetup.js";
-import { logger, getTableNameFromAlias } from "../utils.js";
+import { logger, getTableNameWithAlias } from "../utils.js";
 
 export interface Options extends GlobalOptions {
   name: string;
@@ -27,7 +27,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
 
     // Check if the passed `name` is a table alias
     if (argv.aliases != null)
-      name = await getTableNameFromAlias(argv.aliases, name);
+      name = await getTableNameWithAlias(argv.aliases, name);
     // Check if the passed `name` uses ENS
     // Note: duplicative `setupCommand` calls will occur with ENS, but this is
     // required to properly parse the chainId from the table name

--- a/src/commands/shell.ts
+++ b/src/commands/shell.ts
@@ -10,7 +10,7 @@ const help = `Commands:
 .exit - exit the shell
 .help - show this help
 
-SQL Queries can be multi-line, and must end with a semicolon (;).`;
+SQL Queries can be multi-line, and must end with a semicolon (;)`;
 
 export interface Options extends GlobalOptions {
   statement?: string;
@@ -59,6 +59,8 @@ async function fireFullQuery(
 ): Promise<void> {
   try {
     const { database, ens } = tablelandConnection;
+
+    const aliasesEnabled = database.config.aliases !== undefined;
     if (argv.enableEnsExperiment != null && ens != null) {
       statement = await ens.resolve(statement);
     }
@@ -70,15 +72,37 @@ async function fireFullQuery(
     const response = await stmt.all();
 
     logger.log(JSON.stringify(response.results));
+    const tableName = response.meta.txn?.name;
+    // Check if table aliases are enabled and, if so, include them in the logging
+    let tableAlias;
+    if (aliasesEnabled) {
+      const tableAliases = await database.config.aliases?.read();
+      if (tableAliases) {
+        tableAlias = Object.keys(tableAliases).find(
+          (alias) => tableAliases[alias] === tableName
+        );
+      }
+    }
     switch (type) {
       case "create":
-        logger.log(JSON.stringify({ createdTable: response.meta.txn?.name }));
+        logger.log(
+          JSON.stringify({
+            createdTable: tableName,
+            ...(tableAlias && { alias: tableAlias }),
+          })
+        );
         break;
       case "write":
-        logger.log(JSON.stringify({ updatedTable: response.meta.txn?.name }));
+        logger.log(
+          JSON.stringify({
+            updatedTable: tableName,
+            ...(tableAlias && { alias: tableAlias }),
+          })
+        );
         break;
       default:
     }
+
     /* c8 ignore next 3 */
   } catch (err: any) {
     logger.error(
@@ -105,7 +129,7 @@ async function shellYeah(
         history,
         input: process.stdin,
         output: process.stdout,
-        prompt: "tableland>",
+        prompt: "tableland> ",
         terminal: true,
       });
       rl.prompt();
@@ -131,7 +155,6 @@ async function shellYeah(
             case "help":
             default:
               logger.log(help);
-
               break;
           }
         }
@@ -177,7 +200,7 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
     .option("format", {
       type: "string",
       choices: ["pretty", "table", "objects"] as const,
-      description: "Output format. One of 'pretty', 'table', or 'objects'.",
+      description: "Output format. One of 'pretty', 'table', or 'objects'",
       default: "pretty",
     }) as yargs.Argv<Options>;
 

--- a/src/commands/transfer.ts
+++ b/src/commands/transfer.ts
@@ -33,7 +33,8 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
     let { name } = argv;
 
     // Check if the passed `name` is a table alias
-    if (argv.aliases) name = await getTableNameFromAlias(argv.aliases, name);
+    if (argv.aliases != null)
+      name = await getTableNameFromAlias(argv.aliases, name);
 
     const tableDetails = await globalThis.sqlparser.validateTableName(name);
     const chainId = tableDetails.chainId;

--- a/src/commands/transfer.ts
+++ b/src/commands/transfer.ts
@@ -3,7 +3,7 @@ import type { Arguments, CommandBuilder } from "yargs";
 import { init } from "@tableland/sqlparser";
 import { type GlobalOptions } from "../cli.js";
 import { setupCommand } from "../lib/commandSetup.js";
-import { logger, getTableNameFromAlias } from "../utils.js";
+import { logger, getTableNameWithAlias } from "../utils.js";
 
 export interface Options extends GlobalOptions {
   name: string;
@@ -34,7 +34,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
 
     // Check if the passed `name` is a table alias
     if (argv.aliases != null)
-      name = await getTableNameFromAlias(argv.aliases, name);
+      name = await getTableNameWithAlias(argv.aliases, name);
 
     const tableDetails = await globalThis.sqlparser.validateTableName(name);
     const chainId = tableDetails.chainId;

--- a/src/commands/transfer.ts
+++ b/src/commands/transfer.ts
@@ -3,7 +3,7 @@ import type { Arguments, CommandBuilder } from "yargs";
 import { init } from "@tableland/sqlparser";
 import { type GlobalOptions } from "../cli.js";
 import { setupCommand } from "../lib/commandSetup.js";
-import { logger, jsonFileAliases } from "../utils.js";
+import { logger, getTableNameFromAlias } from "../utils.js";
 
 export interface Options extends GlobalOptions {
   name: string;
@@ -29,35 +29,17 @@ export const builder: CommandBuilder<Record<string, unknown>, Options> = (
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   try {
     await init();
-    const { receiver, chain, aliases } = argv;
+    const { receiver, chain } = argv;
     let { name } = argv;
 
-    let chainId;
-    // Check if the passed `name` is valid, otherwise, if it's a table alias,
-    // making sure standard table names take precedence
-    try {
-      ({ chainId } = await globalThis.sqlparser.validateTableName(name));
-    } catch (err: any) {
-      if (aliases) {
-        try {
-          const nameMap = await jsonFileAliases(aliases).read();
-          const nameFromAlias = nameMap[name];
-          ({ chainId } = await globalThis.sqlparser.validateTableName(
-            nameFromAlias
-          ));
-          name = nameFromAlias;
-        } catch (err: any) {
-          logger.error(
-            "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
-          );
-          return;
-        }
-      }
-    }
+    // Check if the passed `name` is a table alias
+    if (argv.aliases) name = await getTableNameFromAlias(argv.aliases, name);
+
+    const tableDetails = await globalThis.sqlparser.validateTableName(name);
+    const chainId = tableDetails.chainId;
 
     const { registry } = await setupCommand({
       ...argv,
-      // @ts-ignore TODO: fix this
       chain: chain != null ? chain : chainId,
     });
 

--- a/src/commands/write.ts
+++ b/src/commands/write.ts
@@ -108,7 +108,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
           const norm = (await normalize(stmt)) as NormalizedStatement;
           let name = norm.tables[0];
           // Check if the passed `name` is a table alias
-          if (argv.aliases)
+          if (argv.aliases != null)
             name = await getTableNameFromAlias(argv.aliases, name);
           const { tableId } = await globalThis.sqlparser.validateTableName(
             name

--- a/src/commands/write.ts
+++ b/src/commands/write.ts
@@ -6,6 +6,7 @@ import {
   getLink,
   logger,
   getChainName,
+  getTableNameFromAlias,
   type NormalizedStatement,
 } from "../utils.js";
 import { type GlobalOptions } from "../cli.js";
@@ -105,8 +106,12 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
         normalized.statements.map(async function (stmt) {
           // re-normalize so we can be sure we've isolated each statement and it's tableId
           const norm = (await normalize(stmt)) as NormalizedStatement;
+          let name = norm.tables[0];
+          // Check if the passed `name` is a table alias
+          if (argv.aliases)
+            name = await getTableNameFromAlias(argv.aliases, name);
           const { tableId } = await globalThis.sqlparser.validateTableName(
-            norm.tables[0]
+            name
           );
           return {
             statement: stmt,

--- a/src/commands/write.ts
+++ b/src/commands/write.ts
@@ -6,7 +6,7 @@ import {
   getLink,
   logger,
   getChainName,
-  getTableNameFromAlias,
+  getTableNameWithAlias,
   type NormalizedStatement,
 } from "../utils.js";
 import { type GlobalOptions } from "../cli.js";
@@ -109,7 +109,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
           let name = norm.tables[0];
           // Check if the passed `name` is a table alias
           if (argv.aliases != null)
-            name = await getTableNameFromAlias(argv.aliases, name);
+            name = await getTableNameWithAlias(argv.aliases, name);
           const { tableId } = await globalThis.sqlparser.validateTableName(
             name
           );

--- a/src/lib/commandSetup.ts
+++ b/src/lib/commandSetup.ts
@@ -2,7 +2,12 @@ import { helpers, Database, Registry, Validator } from "@tableland/sdk";
 import { init } from "@tableland/sqlparser";
 import { type Signer } from "ethers";
 import { type GlobalOptions } from "../cli.js";
-import { getWalletWithProvider, logger, isValidAliasesFile } from "../utils.js";
+import {
+  getWalletWithProvider,
+  logger,
+  isValidAliasesFile,
+  jsonFileAliases,
+} from "../utils.js";
 import EnsResolver from "./EnsResolver.js";
 
 export class Connections {
@@ -133,11 +138,11 @@ export class Connections {
 
     let aliasesNameMap;
     if (aliases) {
-      const isValid = await isValidAliasesFile(aliases);
+      const isValid = isValidAliasesFile(aliases);
       if (!isValid) {
         throw new Error(`invalid table aliases file`);
       }
-      aliasesNameMap = helpers.jsonFileAliases(aliases);
+      aliasesNameMap = jsonFileAliases(aliases);
     }
 
     this._database = new Database({

--- a/src/lib/commandSetup.ts
+++ b/src/lib/commandSetup.ts
@@ -2,12 +2,7 @@ import { helpers, Database, Registry, Validator } from "@tableland/sdk";
 import { init } from "@tableland/sqlparser";
 import { type Signer } from "ethers";
 import { type GlobalOptions } from "../cli.js";
-import {
-  getWalletWithProvider,
-  logger,
-  isValidAliasesFile,
-  jsonFileAliases,
-} from "../utils.js";
+import { getWalletWithProvider, logger, jsonFileAliases } from "../utils.js";
 import EnsResolver from "./EnsResolver.js";
 
 export class Connections {
@@ -128,7 +123,6 @@ export class Connections {
     if (chain != null) {
       try {
         this._network = helpers.getChainInfo(chain);
-        /* c8 ignore next 3 */
       } catch (e) {
         logger.error("unsupported chain (see `chains` command for details)");
       }
@@ -139,10 +133,6 @@ export class Connections {
 
     let aliasesNameMap;
     if (aliases) {
-      const isValid = isValidAliasesFile(aliases);
-      if (!isValid) {
-        throw new Error(`invalid table aliases file`);
-      }
       aliasesNameMap = jsonFileAliases(aliases);
     }
 

--- a/src/lib/commandSetup.ts
+++ b/src/lib/commandSetup.ts
@@ -101,6 +101,7 @@ export class Connections {
       baseUrl,
       enableEnsExperiment,
       ensProviderUrl,
+      aliases,
     } = argv;
 
     if (privateKey != null && chain != null) {
@@ -135,6 +136,7 @@ export class Connections {
       signer: this._signer,
       baseUrl,
       autoWait: true,
+      aliases: aliases ? helpers.jsonFileAliases(aliases) : undefined,
     });
 
     if (typeof baseUrl === "string" && baseUrl.trim() !== "") {

--- a/src/lib/commandSetup.ts
+++ b/src/lib/commandSetup.ts
@@ -128,6 +128,7 @@ export class Connections {
     if (chain != null) {
       try {
         this._network = helpers.getChainInfo(chain);
+        /* c8 ignore next 3 */
       } catch (e) {
         logger.error("unsupported chain (see `chains` command for details)");
       }

--- a/src/lib/commandSetup.ts
+++ b/src/lib/commandSetup.ts
@@ -132,7 +132,7 @@ export class Connections {
       this._registry = new Registry({ signer: this._signer });
 
     let aliasesNameMap;
-    if (aliases) {
+    if (aliases != null) {
       aliasesNameMap = jsonFileAliases(aliases);
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -189,10 +189,11 @@ interface AliasesNameMap {
   write: (map: NameMapping) => Promise<void>;
 }
 
-// note: slight modification from the original SDK helper
-// since we check if the file exists before calling this, we don't need to use
-// the original `findOrCreateFile` function as no file will be created
 export function jsonFileAliases(filepath: string): AliasesNameMap {
+  const isValid = isValidAliasesFile(filepath);
+  if (!isValid) {
+    throw new Error(`invalid table aliases file`);
+  }
   return {
     read: async function (): Promise<NameMapping> {
       const file = readFileSync(filepath);
@@ -205,4 +206,13 @@ export function jsonFileAliases(filepath: string): AliasesNameMap {
       writeFileSync(filepath, JSON.stringify(merged));
     },
   };
+}
+
+export async function getTableNameFromAlias(
+  path: string,
+  name: string
+): Promise<string> {
+  const nameMap = await jsonFileAliases(path).read();
+  const uuName = nameMap[name];
+  return uuName ?? name;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -209,10 +209,10 @@ export function jsonFileAliases(filepath: string): AliasesNameMap {
 }
 
 export async function getTableNameFromAlias(
-  path: string,
+  filepath: string,
   name: string
 ): Promise<string> {
-  const nameMap = await jsonFileAliases(path).read();
+  const nameMap = await jsonFileAliases(filepath).read();
   const uuName = nameMap[name];
   return uuName ?? name;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
-import { Wallet, providers, getDefaultProvider } from "ethers";
-import { helpers } from "@tableland/sdk";
 import { readFileSync, writeFileSync, statSync } from "node:fs";
 import { extname } from "path";
+import { Wallet, providers, getDefaultProvider } from "ethers";
+import { helpers } from "@tableland/sdk";
 
 export const getChains = function (): typeof helpers.supportedChains {
   return Object.fromEntries(
@@ -82,7 +82,7 @@ export async function getWalletWithProvider({
 
   const wallet = new Wallet(privateKey);
 
-  // We want to aquire a provider using the params given by the caller.
+  // We want to acquire a provider using the params given by the caller.
   let provider: providers.BaseProvider | undefined;
   // first we check if a providerUrl was given.
   if (typeof providerUrl === "string") {
@@ -128,7 +128,7 @@ export async function getWalletWithProvider({
   return wallet.connect(provider);
 }
 
-// Wrap any direct calls to console.log, so that test spies can distinguise between
+// Wrap any direct calls to console.log, so that test spies can distinguish between
 // the CLI's output, and messaging that originates outside the CLI
 export const logger = {
   log: function (message: string) {
@@ -149,7 +149,7 @@ export const logger = {
  * @returns The type of the path, either "file" or "dir".
  */
 /* c8 ignore start */
-export function checkAliasesPath(path: string) {
+export function checkAliasesPath(path: string): string {
   let type;
   let isStatErr;
   try {
@@ -159,7 +159,7 @@ export function checkAliasesPath(path: string) {
   } catch {
     isStatErr = true;
   }
-  if (type === undefined || isStatErr)
+  if (type === undefined || isStatErr != null)
     throw new Error("invalid table aliases path");
   return type;
 }
@@ -170,7 +170,7 @@ export function checkAliasesPath(path: string) {
  * @param path Path to existing aliases file.
  * @returns true if the file exists and is JSON, false otherwise.
  */
-export function isValidAliasesFile(path: string) {
+export function isValidAliasesFile(path: string): boolean {
   try {
     const stats = statSync(path);
     if (stats.isFile() && extname(path) === ".json") return true;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 import { Wallet, providers, getDefaultProvider } from "ethers";
 import { helpers } from "@tableland/sdk";
+import { stat } from "node:fs/promises";
+import { extname } from "path";
 
 export const getChains = function (): typeof helpers.supportedChains {
   return Object.fromEntries(
@@ -139,3 +141,16 @@ export const logger = {
     console.error(message);
   },
 };
+
+// Check if a table aliases file exists, or if a directory exists where we can create one
+export async function checkPath(path: string) {
+  try {
+    const stats = await stat(path);
+    if (stats.isFile()) {
+      return extname(path) === ".json" ? "file" : "invalid";
+    }
+    return stats.isDirectory() ? "dir" : "invalid";
+  } catch (err) {
+    return "invalid";
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,8 +36,8 @@ export const wait = async (timeout: number): Promise<void> =>
 export function getLink(chain: helpers.ChainName, hash: string): string {
   /* c8 ignore start */
   if (chain.includes("ethereum")) {
-    if (chain.includes("goerli")) {
-      return `https://goerli.etherscan.io/tx/${hash}`;
+    if (chain.includes("sepolia")) {
+      return `https://sepolia.etherscan.io/tx/${hash}`;
     }
     return `https://etherscan.io/tx/${hash}`;
   } else if (chain.includes("polygon")) {
@@ -47,12 +47,15 @@ export function getLink(chain: helpers.ChainName, hash: string): string {
     return `https://polygonscan.com/tx/${hash}`;
   } else if (chain.includes("optimism")) {
     if (chain.includes("goerli")) {
-      return `https://blockscout.com/optimism/goerli/tx/${hash}`;
+      return `https://goerli-optimism.etherscan.io/tx/${hash}`;
     }
     return `https://optimistic.etherscan.io/tx/${hash}`;
   } else if (chain.includes("arbitrum")) {
     if (chain.includes("goerli")) {
-      return `https://goerli-rollup-explorer.arbitrum.io/tx/${hash}`;
+      return `https://goerli.arbiscan.io/tx/${hash}`;
+    }
+    if (chain.includes("nova")) {
+      return `https://nova.arbiscan.io/tx/${hash}`;
     }
     return `https://arbiscan.io/tx/${hash}`;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -148,6 +148,7 @@ export const logger = {
  * @param path Path to existing aliases file or directory to create one at.
  * @returns The type of the path, either "file" or "dir".
  */
+/* c8 ignore start */
 export function checkAliasesPath(path: string) {
   let type;
   let isStatErr;
@@ -162,6 +163,7 @@ export function checkAliasesPath(path: string) {
     throw new Error("invalid table aliases path");
   return type;
 }
+/* c8 ignore stop */
 
 /**
  * Check if a table aliases file exists and is JSON.
@@ -173,6 +175,7 @@ export function isValidAliasesFile(path: string) {
     const stats = statSync(path);
     if (stats.isFile() && extname(path) === ".json") return true;
   } catch {
+    /* c8 ignore next 4 */
     return false;
   }
   return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -208,7 +208,7 @@ export function jsonFileAliases(filepath: string): AliasesNameMap {
   };
 }
 
-export async function getTableNameFromAlias(
+export async function getTableNameWithAlias(
   filepath: string,
   name: string
 ): Promise<string> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,7 +121,7 @@ export async function getWalletWithProvider({
   }
 
   if (providerChainId !== network.chainId) {
-    throw new Error("provider / chain mismatch.");
+    throw new Error("provider / chain mismatch");
   }
 
   /* c8 ignore stop */
@@ -142,15 +142,38 @@ export const logger = {
   },
 };
 
-// Check if a table aliases file exists, or if a directory exists where we can create one
-export async function checkPath(path: string) {
+/**
+ * Check if a table aliases file exists, or if a directory exists where we can
+ * create a new one (note: only used with `init`, where creation can happen).
+ * @param path Path to existing aliases file or directory to create one at.
+ * @returns The type of the path, either "file" or "dir".
+ */
+export async function checkAliasesPath(path: string) {
+  let type;
+  let isStatErr;
   try {
     const stats = await stat(path);
-    if (stats.isFile()) {
-      return extname(path) === ".json" ? "file" : "invalid";
-    }
-    return stats.isDirectory() ? "dir" : "invalid";
-  } catch (err) {
-    return "invalid";
+    if (stats.isFile() && extname(path) === ".json") type = "file"; // only set "type" if it's JSON
+    if (stats.isDirectory()) type = "dir";
+  } catch {
+    isStatErr = true;
   }
+  if (type === undefined || isStatErr)
+    throw new Error("invalid table aliases path");
+  return type;
+}
+
+/**
+ * Check if a table aliases file exists and is JSON.
+ * @param path Path to existing aliases file.
+ * @returns true if the file exists and is JSON, false otherwise.
+ */
+export async function isValidAliasesFile(path: string) {
+  try {
+    const stats = await stat(path);
+    if (stats.isFile() && extname(path) === ".json") return true;
+  } catch {
+    return false;
+  }
+  return false;
 }

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -201,10 +201,7 @@ describe("commands/controller", function () {
         .parse();
 
       const value = consoleError.getCall(0).firstArg;
-      equal(
-        value,
-        "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
-      );
+      match(value, /error validating name: table name has wrong format:/);
     });
 
     test("throws with invalid set arguments", async function () {
@@ -231,10 +228,7 @@ describe("commands/controller", function () {
         .parse();
 
       const value = consoleError.getCall(0).firstArg;
-      equal(
-        value,
-        "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
-      );
+      match(value, /error validating name: table name has wrong format:/);
     });
 
     test("throws with invalid lock arguments", async function () {
@@ -260,10 +254,7 @@ describe("commands/controller", function () {
         .parse();
 
       const value = consoleError.getCall(0).firstArg;
-      equal(
-        value,
-        "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
-      );
+      match(value, /error validating name: table name has wrong format:/);
     });
 
     test("passes when setting a controller", async function () {

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -279,9 +279,10 @@ describe("commands/controller", function () {
 
       // Check the aliases file was updated and matches with the prefix
       const nameMap = await jsonFileAliases(aliasesFilePath).read();
-      const tableAlias = Object.keys(nameMap).find(
-        (alias) => nameMap[alias] === nameFromCreate
-      );
+      const tableAlias =
+        Object.keys(nameMap).find(
+          (alias) => nameMap[alias] === nameFromCreate
+        ) ?? "";
       equal(tableAlias, prefix);
 
       // Now, set the controller
@@ -290,7 +291,7 @@ describe("commands/controller", function () {
         "controller",
         "set",
         accounts[2].address,
-        tableAlias!,
+        tableAlias,
         "--privateKey",
         privateKey,
         "--chain",
@@ -305,7 +306,7 @@ describe("commands/controller", function () {
       const { hash, link } = JSON.parse(res);
       equal(typeof hash, "string");
       equal(hash.startsWith("0x"), true);
-      equal(!link, true);
+      equal(link != null, true);
     });
 
     test("passes when getting a controller", async function () {
@@ -330,9 +331,10 @@ describe("commands/controller", function () {
 
       // Check the aliases file was updated and matches with the prefix
       const nameMap = await jsonFileAliases(aliasesFilePath).read();
-      const tableAlias = Object.keys(nameMap).find(
-        (alias) => nameMap[alias] === nameFromCreate
-      );
+      const tableAlias =
+        Object.keys(nameMap).find(
+          (alias) => nameMap[alias] === nameFromCreate
+        ) ?? "";
       equal(tableAlias, prefix);
 
       // Now, get the controller
@@ -340,7 +342,7 @@ describe("commands/controller", function () {
       await yargs([
         "controller",
         "get",
-        tableAlias!,
+        tableAlias,
         "--privateKey",
         privateKey,
         "--chain",
@@ -377,9 +379,10 @@ describe("commands/controller", function () {
 
       // Check the aliases file was updated and matches with the prefix
       const nameMap = await jsonFileAliases(aliasesFilePath).read();
-      const tableAlias = Object.keys(nameMap).find(
-        (alias) => nameMap[alias] === nameFromCreate
-      );
+      const tableAlias =
+        Object.keys(nameMap).find(
+          (alias) => nameMap[alias] === nameFromCreate
+        ) ?? "";
       equal(tableAlias, prefix);
 
       // Now, lock the controller
@@ -387,7 +390,7 @@ describe("commands/controller", function () {
       await yargs([
         "controller",
         "lock",
-        tableAlias!,
+        tableAlias,
         "--privateKey",
         privateKey,
         "--chain",

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -93,6 +93,25 @@ describe("commands/controller", function () {
     match(value, /error validating name: table name has wrong format:/);
   });
 
+  test("throws with invalid lock arguments", async function () {
+    const privateKey = accounts[1].privateKey.slice(2);
+    const consoleError = spy(logger, "error");
+    await yargs([
+      "controller",
+      "lock",
+      "invalid",
+      "--privateKey",
+      privateKey,
+      "--chain",
+      "local-tableland",
+    ])
+      .command(mod)
+      .parse();
+
+    const value = consoleError.getCall(0).firstArg;
+    match(value, /error validating name: table name has wrong format:/);
+  });
+
   test("passes when setting a controller", async function () {
     const privateKey = accounts[1].privateKey.slice(2);
     const consoleLog = spy(logger, "log");
@@ -159,6 +178,94 @@ describe("commands/controller", function () {
   });
 
   describe("with table aliases", function () {
+    test("throws with invalid get arguments", async function () {
+      const [account] = accounts;
+      const privateKey = account.privateKey.slice(2);
+      const aliasesFilePath = await temporaryWrite(`{}`, {
+        extension: "json",
+      });
+
+      const consoleError = spy(logger, "error");
+      await yargs([
+        "controller",
+        "get",
+        "invalid",
+        "--privateKey",
+        privateKey,
+        "--chain",
+        "local-tableland",
+        "--aliases",
+        aliasesFilePath,
+      ])
+        .command(mod)
+        .parse();
+
+      const value = consoleError.getCall(0).firstArg;
+      equal(
+        value,
+        "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
+      );
+    });
+
+    test("throws with invalid set arguments", async function () {
+      const [account] = accounts;
+      const privateKey = account.privateKey.slice(2);
+      const aliasesFilePath = await temporaryWrite(`{}`, {
+        extension: "json",
+      });
+
+      const consoleError = spy(logger, "error");
+      await yargs([
+        "controller",
+        "set",
+        "invalid",
+        "invalid",
+        "--privateKey",
+        privateKey,
+        "--chain",
+        "local-tableland",
+        "--aliases",
+        aliasesFilePath,
+      ])
+        .command(mod)
+        .parse();
+
+      const value = consoleError.getCall(0).firstArg;
+      equal(
+        value,
+        "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
+      );
+    });
+
+    test("throws with invalid lock arguments", async function () {
+      const [account] = accounts;
+      const privateKey = account.privateKey.slice(2);
+      const aliasesFilePath = await temporaryWrite(`{}`, {
+        extension: "json",
+      });
+
+      const consoleError = spy(logger, "error");
+      await yargs([
+        "controller",
+        "lock",
+        "invalid",
+        "--privateKey",
+        privateKey,
+        "--chain",
+        "local-tableland",
+        "--aliases",
+        aliasesFilePath,
+      ])
+        .command(mod)
+        .parse();
+
+      const value = consoleError.getCall(0).firstArg;
+      equal(
+        value,
+        "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
+      );
+    });
+
     test("passes when setting a controller", async function () {
       const [account] = accounts;
       const privateKey = account.privateKey.slice(2);

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -458,4 +458,30 @@ describe("commands/create", function () {
     );
     equal(tableAlias, prefix);
   });
+
+  test("fails with invalid table alias file", async function () {
+    const [account] = accounts;
+    const privateKey = account.privateKey.slice(2);
+    const consoleError = spy(logger, "error");
+    // Set up faux aliases file
+    const aliasesFilePath = "./invalid.json";
+
+    await yargs([
+      "create",
+      "id int",
+      "--prefix",
+      "table_aliases",
+      "--chain",
+      "local-tableland",
+      "--privateKey",
+      privateKey,
+      "--aliases",
+      aliasesFilePath,
+    ])
+      .command(mod)
+      .parse();
+
+    const res = consoleError.getCall(0).firstArg;
+    equal(res, "invalid table aliases file");
+  });
 });

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -6,7 +6,6 @@ import { temporaryWrite } from "tempy";
 import mockStd from "mock-stdin";
 import { getAccounts } from "@tableland/local";
 import { ethers } from "ethers";
-import { helpers } from "@tableland/sdk";
 import * as mod from "../src/commands/create.js";
 import { wait, logger, jsonFileAliases } from "../src/utils.js";
 import { getResolverMock } from "./mock.js";

--- a/test/info.test.ts
+++ b/test/info.test.ts
@@ -9,8 +9,8 @@ import { temporaryWrite } from "tempy";
 import ensLib from "../src/lib/EnsCommand";
 import * as mod from "../src/commands/info.js";
 import * as ns from "../src/commands/namespace.js";
-import { getResolverMock } from "./mock.js";
 import { jsonFileAliases, logger, wait } from "../src/utils.js";
+import { getResolverMock } from "./mock.js";
 
 describe("commands/info", function () {
   this.timeout("30s");
@@ -122,11 +122,9 @@ describe("commands/info", function () {
         },
       };
     });
-    stub(
-      ethers.providers.JsonRpcProvider.prototype,
-      "getResolver"
-      // @ts-ignore
-    ).callsFake(getResolverMock);
+    stub(ethers.providers.JsonRpcProvider.prototype, "getResolver").callsFake(
+      getResolverMock
+    );
 
     const consoleLog = spy(logger, "log");
     await yargs([
@@ -185,11 +183,9 @@ describe("commands/info", function () {
         },
       };
     });
-    stub(
-      ethers.providers.JsonRpcProvider.prototype,
-      "getResolver"
-      // @ts-ignore
-    ).callsFake(getResolverMock);
+    stub(ethers.providers.JsonRpcProvider.prototype, "getResolver").callsFake(
+      getResolverMock
+    );
 
     const consoleLog = spy(logger, "log");
     await yargs([
@@ -262,16 +258,16 @@ describe("commands/info", function () {
 
     // Check the aliases file was updated and matches with the prefix
     const nameMap = await jsonFileAliases(aliasesFilePath).read();
-    const tableAlias = Object.keys(nameMap).find(
-      (alias) => nameMap[alias] === nameFromCreate
-    );
+    const tableAlias =
+      Object.keys(nameMap).find((alias) => nameMap[alias] === nameFromCreate) ??
+      "";
     equal(tableAlias, prefix);
 
     // Get table info via alias
     const consoleLog = spy(logger, "log");
     await yargs([
       "info",
-      tableAlias!,
+      tableAlias,
       "--chain",
       "local-tableland",
       "--baseUrl",

--- a/test/info.test.ts
+++ b/test/info.test.ts
@@ -50,27 +50,7 @@ describe("commands/info", function () {
     equal(value, "Not Found");
   });
 
-  test("throws with valid ENS name but no namespace record set", async function () {
-    const consoleError = spy(logger, "error");
-    await yargs([
-      "info",
-      "foo.bar.eth",
-      "--chain",
-      "local-tableland",
-      "--baseUrl",
-      "http://localhost:8080/api/v1",
-      "--enableEnsExperiment",
-      "--ensProviderUrl",
-      "https://localhost:7070",
-    ])
-      .command(mod)
-      .parse();
-
-    const value = consoleError.getCall(0).firstArg;
-    equal(value, "invalid ENS namespace, table record not found");
-  });
-
-  test("throws with invalid table alias", async function () {
+  test("throws with invalid table aliases file", async function () {
     const consoleError = spy(logger, "error");
     await yargs([
       "info",
@@ -86,7 +66,33 @@ describe("commands/info", function () {
       .parse();
 
     const value = consoleError.getCall(0).firstArg;
-    equal(value, "invalid table alias, table name not found");
+    equal(value, "invalid table aliases file");
+  });
+
+  test("throws with invalid table alias definition", async function () {
+    // Set up test aliases file
+    const aliasesFilePath = await temporaryWrite(`{}`, {
+      extension: "json",
+    });
+    const consoleError = spy(logger, "error");
+    await yargs([
+      "info",
+      "table_alias",
+      "--chain",
+      "local-tableland",
+      "--baseUrl",
+      "http://localhost:8080/api/v1",
+      "--aliases",
+      aliasesFilePath,
+    ])
+      .command(mod)
+      .parse();
+
+    const value = consoleError.getCall(0).firstArg;
+    equal(
+      value,
+      "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
+    );
   });
 
   test("passes with local-tableland", async function () {

--- a/test/info.test.ts
+++ b/test/info.test.ts
@@ -1,22 +1,29 @@
 import { equal } from "node:assert";
 import { describe, test, afterEach, before } from "mocha";
-import { spy, restore } from "sinon";
+import { spy, restore, stub } from "sinon";
 import yargs from "yargs/yargs";
+import { ethers } from "ethers";
+import { getAccounts } from "@tableland/local";
+import { helpers, Database } from "@tableland/sdk";
+import { temporaryWrite } from "tempy";
+import ensLib from "../src/lib/EnsCommand";
 import * as mod from "../src/commands/info.js";
-import { wait, logger } from "../src/utils.js";
+import * as ns from "../src/commands/namespace.js";
+import { getResolverMock } from "./mock.js";
+import { jsonFileAliases, logger, wait } from "../src/utils.js";
 
 describe("commands/info", function () {
   this.timeout("30s");
 
   before(async function () {
-    await wait(10000);
+    await wait(1000);
   });
 
   afterEach(function () {
     restore();
   });
 
-  test("info throws with invalid table name", async function () {
+  test("throws with invalid table name", async function () {
     const consoleError = spy(logger, "error");
     await yargs(["info", "invalid_name"]).command(mod).parse();
 
@@ -27,7 +34,7 @@ describe("commands/info", function () {
     );
   });
 
-  test("info throws with invalid chain", async function () {
+  test("throws with invalid chain", async function () {
     const consoleError = spy(logger, "error");
     await yargs(["info", "valid_9999_0"]).command(mod).parse();
 
@@ -35,7 +42,54 @@ describe("commands/info", function () {
     equal(value, "unsupported chain (see `chains` command for details)");
   });
 
-  test("Info passes with local-tableland", async function () {
+  test("throws with missing table", async function () {
+    const consoleError = spy(logger, "error");
+    await yargs(["info", "ignored_31337_99"]).command(mod).parse();
+
+    const value = consoleError.getCall(0).firstArg;
+    equal(value, "Not Found");
+  });
+
+  test("throws with valid ENS name but no namespace record set", async function () {
+    const consoleError = spy(logger, "error");
+    await yargs([
+      "info",
+      "foo.bar.eth",
+      "--chain",
+      "local-tableland",
+      "--baseUrl",
+      "http://localhost:8080/api/v1",
+      "--enableEnsExperiment",
+      "--ensProviderUrl",
+      "https://localhost:7070",
+    ])
+      .command(mod)
+      .parse();
+
+    const value = consoleError.getCall(0).firstArg;
+    equal(value, "invalid ENS namespace, table record not found");
+  });
+
+  test("throws with invalid table alias", async function () {
+    const consoleError = spy(logger, "error");
+    await yargs([
+      "info",
+      "table_alias",
+      "--chain",
+      "local-tableland",
+      "--baseUrl",
+      "http://localhost:8080/api/v1",
+      "--aliases",
+      "./invalid.json",
+    ])
+      .command(mod)
+      .parse();
+
+    const value = consoleError.getCall(0).firstArg;
+    equal(value, "invalid table alias, table name not found");
+  });
+
+  test("passes with local-tableland", async function () {
     const consoleLog = spy(logger, "log");
     await yargs(["info", "healthbot_31337_1"]).command(mod).parse();
 
@@ -48,11 +102,115 @@ describe("commands/info", function () {
     equal(Array.isArray(attributes), true);
   });
 
-  test("info throws with missing table", async function () {
-    const consoleError = spy(logger, "error");
-    await yargs(["info", "ignored_31337_99"]).command(mod).parse();
+  test("passes with valid ENS name", async function () {
+    // Must do initial ENS setup and set the record name to the table
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    stub(ensLib, "ENS").callsFake(function () {
+      return {
+        withProvider: () => {
+          return {
+            setRecords: async () => {
+              return false;
+            },
+          };
+        },
+      };
+    });
+    stub(
+      ethers.providers.JsonRpcProvider.prototype,
+      "getResolver"
+      // @ts-ignore
+    ).callsFake(getResolverMock);
 
-    const value = consoleError.getCall(0).firstArg;
-    equal(value, "Not Found");
+    const consoleLog = spy(logger, "log");
+    await yargs([
+      "namespace",
+      "set",
+      "foo.bar.eth",
+      "healthbot=healthbot_31337_1",
+      "--enableEnsExperiment",
+      "--ensProviderUrl",
+      "https://localhost:7070",
+    ])
+      .command(ns)
+      .parse();
+
+    let res = consoleLog.getCall(0).firstArg;
+    let value = JSON.parse(res);
+    equal(value.domain, "foo.bar.eth");
+    equal(value.records[0].key, "healthbot");
+    equal(value.records[0].value, "healthbot_31337_1");
+
+    // Now, check the table info using ENS as the name
+    await yargs([
+      "info",
+      "foo.bar.eth",
+      "--chain",
+      "local-tableland",
+      "--baseUrl",
+      "http://localhost:8080/api/v1",
+      "--enableEnsExperiment",
+      "--ensProviderUrl",
+      "https://localhost:7070",
+    ])
+      .command(mod)
+      .parse();
+
+    res = consoleLog.getCall(1).firstArg;
+    value = JSON.parse(res);
+    const { name, attributes, externalUrl } = value;
+
+    equal(name, "healthbot_31337_1");
+    equal(externalUrl, "http://localhost:8080/api/v1/tables/31337/1");
+    equal(Array.isArray(attributes), true);
+  });
+
+  test("passes with table aliases", async function () {
+    const [account] = getAccounts();
+    // Set up test aliases file
+    const aliasesFilePath = await temporaryWrite(`{}`, {
+      extension: "json",
+    });
+    // Create new db instance to enable aliases
+    const db = new Database({
+      signer: account,
+      baseUrl: helpers.getBaseUrl("local-tableland"),
+      autoWait: true,
+      aliases: jsonFileAliases(aliasesFilePath),
+    });
+    const { meta } = await db
+      .prepare("CREATE TABLE table_aliases (id int);")
+      .all();
+    const nameFromCreate = meta.txn?.name ?? "";
+    const prefix = meta.txn?.prefix ?? "";
+
+    // Check the aliases file was updated and matches with the prefix
+    const nameMap = await jsonFileAliases(aliasesFilePath).read();
+    const tableAlias = Object.keys(nameMap).find(
+      (alias) => nameMap[alias] === nameFromCreate
+    );
+    equal(tableAlias, prefix);
+
+    // Get table info via alias
+    const consoleLog = spy(logger, "log");
+    await yargs([
+      "info",
+      tableAlias!,
+      "--chain",
+      "local-tableland",
+      "--baseUrl",
+      "http://localhost:8080/api/v1",
+      "--aliases",
+      aliasesFilePath,
+    ])
+      .command(mod)
+      .parse();
+
+    const res = consoleLog.getCall(0).firstArg;
+    const value = JSON.parse(res);
+    const { name: nameFromInfo, attributes } = value;
+
+    equal(nameFromInfo, nameFromCreate);
+    equal(Array.isArray(attributes), true);
   });
 });

--- a/test/list.test.ts
+++ b/test/list.test.ts
@@ -4,11 +4,11 @@ import { spy, restore } from "sinon";
 import { getAccounts } from "@tableland/local";
 import yargs from "yargs/yargs";
 import * as mod from "../src/commands/list.js";
-import { logger } from "../src/utils.js";
+import { logger, wait } from "../src/utils.js";
 
 describe("commands/list", function () {
   before(async function () {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await wait(1000);
   });
 
   afterEach(function () {

--- a/test/namespace.test.ts
+++ b/test/namespace.test.ts
@@ -67,7 +67,7 @@ describe("commands/namespace", function () {
     );
   });
 
-  test("fails if ens name is invalid", async function () {
+  test("fails if ENS name is invalid", async function () {
     const consoleError = spy(logger, "error");
     await yargs([
       "namespace",
@@ -82,7 +82,7 @@ describe("commands/namespace", function () {
       .parse();
 
     const value = consoleError.getCall(0).firstArg;
-    equal(value, "Only letters or underscores in key name");
+    equal(value, "only letters or underscores in key name");
   });
 
   test("fails if table name is invalid", async function () {
@@ -100,10 +100,10 @@ describe("commands/namespace", function () {
       .parse();
 
     const value = consoleError.getCall(0).firstArg;
-    equal(value, "Tablename is invalid");
+    equal(value, "table name is invalid");
   });
 
-  test("Get ENS name", async function () {
+  test("get ENS name", async function () {
     stub(ethers.providers.JsonRpcProvider.prototype, "getResolver").callsFake(
       getResolverMock
     );
@@ -125,7 +125,7 @@ describe("commands/namespace", function () {
     equal(value.value, "healthbot_31337_1");
   });
 
-  test("Set ENS name", async function () {
+  test("set ENS name", async function () {
     const consoleLog = spy(logger, "log");
     await yargs([
       "namespace",

--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -366,9 +366,8 @@ describe("commands/read", function () {
 
     // Check the aliases file was updated and matches with the prefix
     const nameMap = await jsonFileAliases(aliasesFilePath).read();
-    const tableAlias = Object.keys(nameMap).find(
-      (alias) => nameMap[alias] === name
-    );
+    const tableAlias =
+      Object.keys(nameMap).find((alias) => nameMap[alias] === name) ?? "";
     equal(tableAlias, prefix);
 
     // Write to the table

--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -364,4 +364,28 @@ describe("commands/read", function () {
     const value = consoleLog.getCall(0).firstArg;
     deepStrictEqual(value, '[{"id":1}]');
   });
+
+  test("fails with invalid table alias file", async function () {
+    const [account] = accounts;
+    const privateKey = account.privateKey.slice(2);
+    const consoleError = spy(logger, "error");
+    // Set up faux aliases file
+    const aliasesFilePath = "./invalid.json";
+
+    await yargs([
+      "read",
+      "SELECT * FROM table_aliases;",
+      "--chain",
+      "local-tableland",
+      "--privateKey",
+      privateKey,
+      "--aliases",
+      aliasesFilePath,
+    ])
+      .command(mod)
+      .parse();
+
+    const res = consoleError.getCall(0).firstArg;
+    equal(res, "invalid table aliases file");
+  });
 });

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -50,27 +50,7 @@ describe("commands/schema", function () {
     equal(value, "Not Found");
   });
 
-  test("throws with valid ENS name but no namespace record set", async function () {
-    const consoleError = spy(logger, "error");
-    await yargs([
-      "schema",
-      "foo.bar.eth",
-      "--chain",
-      "local-tableland",
-      "--baseUrl",
-      "http://localhost:8080/api/v1",
-      "--enableEnsExperiment",
-      "--ensProviderUrl",
-      "https://localhost:7070",
-    ])
-      .command(mod)
-      .parse();
-
-    const value = consoleError.getCall(0).firstArg;
-    equal(value, "invalid ENS namespace, table record not found");
-  });
-
-  test("throws with invalid table alias", async function () {
+  test("throws with invalid table aliases file", async function () {
     const consoleError = spy(logger, "error");
     await yargs([
       "schema",
@@ -86,7 +66,33 @@ describe("commands/schema", function () {
       .parse();
 
     const value = consoleError.getCall(0).firstArg;
-    equal(value, "invalid table alias, table name not found");
+    equal(value, "invalid table aliases file");
+  });
+
+  test("throws with invalid table alias definition", async function () {
+    // Set up test aliases file
+    const aliasesFilePath = await temporaryWrite(`{}`, {
+      extension: "json",
+    });
+    const consoleError = spy(logger, "error");
+    await yargs([
+      "schema",
+      "table_alias",
+      "--chain",
+      "local-tableland",
+      "--baseUrl",
+      "http://localhost:8080/api/v1",
+      "--aliases",
+      aliasesFilePath,
+    ])
+      .command(mod)
+      .parse();
+
+    const value = consoleError.getCall(0).firstArg;
+    equal(
+      value,
+      "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
+    );
   });
 
   test("passes with local-tableland", async function () {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -9,8 +9,8 @@ import { temporaryWrite } from "tempy";
 import ensLib from "../src/lib/EnsCommand";
 import * as mod from "../src/commands/schema";
 import * as ns from "../src/commands/namespace.js";
-import { getResolverMock } from "./mock.js";
 import { jsonFileAliases, logger, wait } from "../src/utils.js";
+import { getResolverMock } from "./mock.js";
 
 describe("commands/schema", function () {
   this.timeout("30s");
@@ -117,11 +117,9 @@ describe("commands/schema", function () {
         },
       };
     });
-    stub(
-      ethers.providers.JsonRpcProvider.prototype,
-      "getResolver"
-      // @ts-ignore
-    ).callsFake(getResolverMock);
+    stub(ethers.providers.JsonRpcProvider.prototype, "getResolver").callsFake(
+      getResolverMock
+    );
 
     const consoleLog = spy(logger, "log");
     await yargs([
@@ -175,11 +173,9 @@ describe("commands/schema", function () {
         },
       };
     });
-    stub(
-      ethers.providers.JsonRpcProvider.prototype,
-      "getResolver"
-      // @ts-ignore
-    ).callsFake(getResolverMock);
+    stub(ethers.providers.JsonRpcProvider.prototype, "getResolver").callsFake(
+      getResolverMock
+    );
 
     const consoleLog = spy(logger, "log");
     await yargs([
@@ -247,14 +243,14 @@ describe("commands/schema", function () {
 
     // Check the aliases file was updated and matches with the prefix
     const nameMap = await jsonFileAliases(aliasesFilePath).read();
-    const tableAlias = Object.keys(nameMap).find(
-      (alias) => nameMap[alias] === nameFromCreate
-    );
+    const tableAlias =
+      Object.keys(nameMap).find((alias) => nameMap[alias] === nameFromCreate) ??
+      "";
     equal(tableAlias, prefix);
 
     // Get table schema via alias
     const consoleLog = spy(logger, "log");
-    await yargs(["schema", tableAlias!, "--aliases", aliasesFilePath])
+    await yargs(["schema", tableAlias, "--aliases", aliasesFilePath])
       .command(mod)
       .parse();
 

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -1,11 +1,20 @@
 import { equal } from "node:assert";
 import { describe, test, afterEach, before } from "mocha";
-import { spy, restore } from "sinon";
+import { spy, restore, stub } from "sinon";
 import yargs from "yargs/yargs";
-import * as mod from "../src/commands/schema.js";
-import { wait, logger } from "../src/utils.js";
+import { ethers } from "ethers";
+import { getAccounts } from "@tableland/local";
+import { helpers, Database } from "@tableland/sdk";
+import { temporaryWrite } from "tempy";
+import ensLib from "../src/lib/EnsCommand";
+import * as mod from "../src/commands/schema";
+import * as ns from "../src/commands/namespace.js";
+import { getResolverMock } from "./mock.js";
+import { jsonFileAliases, logger, wait } from "../src/utils.js";
 
 describe("commands/schema", function () {
+  this.timeout("30s");
+
   before(async function () {
     await wait(1000);
   });
@@ -14,7 +23,7 @@ describe("commands/schema", function () {
     restore();
   });
 
-  test("throws without invalid table name", async function () {
+  test("throws with invalid table name", async function () {
     const consoleError = spy(logger, "error");
     await yargs(["schema", "invalid_name"]).command(mod).parse();
 
@@ -41,11 +50,144 @@ describe("commands/schema", function () {
     equal(value, "Not Found");
   });
 
-  test("Schema passes with local-tableland", async function () {
+  test("throws with valid ENS name but no namespace record set", async function () {
+    const consoleError = spy(logger, "error");
+    await yargs([
+      "schema",
+      "foo.bar.eth",
+      "--chain",
+      "local-tableland",
+      "--baseUrl",
+      "http://localhost:8080/api/v1",
+      "--enableEnsExperiment",
+      "--ensProviderUrl",
+      "https://localhost:7070",
+    ])
+      .command(mod)
+      .parse();
+
+    const value = consoleError.getCall(0).firstArg;
+    equal(value, "invalid ENS namespace, table record not found");
+  });
+
+  test("throws with invalid table alias", async function () {
+    const consoleError = spy(logger, "error");
+    await yargs([
+      "schema",
+      "table_alias",
+      "--chain",
+      "local-tableland",
+      "--baseUrl",
+      "http://localhost:8080/api/v1",
+      "--aliases",
+      "./invalid.json",
+    ])
+      .command(mod)
+      .parse();
+
+    const value = consoleError.getCall(0).firstArg;
+    equal(value, "invalid table alias, table name not found");
+  });
+
+  test("passes with local-tableland", async function () {
     const consoleLog = spy(logger, "log");
     await yargs(["schema", "healthbot_31337_1"]).command(mod).parse();
 
     const value = consoleLog.getCall(0).firstArg;
     equal(value, `{"columns":[{"name":"counter","type":"integer"}]}`);
+  });
+
+  test("passes with valid ENS name", async function () {
+    // Must do initial ENS setup and set the record name to the table
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    stub(ensLib, "ENS").callsFake(function () {
+      return {
+        withProvider: () => {
+          return {
+            setRecords: async () => {
+              return false;
+            },
+          };
+        },
+      };
+    });
+    stub(
+      ethers.providers.JsonRpcProvider.prototype,
+      "getResolver"
+      // @ts-ignore
+    ).callsFake(getResolverMock);
+
+    const consoleLog = spy(logger, "log");
+    await yargs([
+      "namespace",
+      "set",
+      "foo.bar.eth",
+      "healthbot=healthbot_31337_1",
+      "--enableEnsExperiment",
+      "--ensProviderUrl",
+      "https://localhost:7070",
+    ])
+      .command(ns)
+      .parse();
+
+    let res = consoleLog.getCall(0).firstArg;
+    const value = JSON.parse(res);
+    equal(value.domain, "foo.bar.eth");
+    equal(value.records[0].key, "healthbot");
+    equal(value.records[0].value, "healthbot_31337_1");
+
+    // Now, check the table schema using ENS as the name
+    await yargs([
+      "schema",
+      "foo.bar.eth",
+      "--chain",
+      "local-tableland",
+      "--baseUrl",
+      "http://localhost:8080/api/v1",
+      "--enableEnsExperiment",
+      "--ensProviderUrl",
+      "https://localhost:7070",
+    ])
+      .command(mod)
+      .parse();
+
+    res = consoleLog.getCall(1).firstArg;
+    equal(res, `{"columns":[{"name":"counter","type":"integer"}]}`);
+  });
+
+  test("passes with table aliases", async function () {
+    const [account] = getAccounts();
+    // Set up test aliases file
+    const aliasesFilePath = await temporaryWrite(`{}`, {
+      extension: "json",
+    });
+    // Create new db instance to enable aliases
+    const db = new Database({
+      signer: account,
+      baseUrl: helpers.getBaseUrl("local-tableland"),
+      autoWait: true,
+      aliases: jsonFileAliases(aliasesFilePath),
+    });
+    const { meta } = await db
+      .prepare("CREATE TABLE table_aliases (id int);")
+      .all();
+    const nameFromCreate = meta.txn?.name ?? "";
+    const prefix = meta.txn?.prefix ?? "";
+
+    // Check the aliases file was updated and matches with the prefix
+    const nameMap = await jsonFileAliases(aliasesFilePath).read();
+    const tableAlias = Object.keys(nameMap).find(
+      (alias) => nameMap[alias] === nameFromCreate
+    );
+    equal(tableAlias, prefix);
+
+    // Get table schema via alias
+    const consoleLog = spy(logger, "log");
+    await yargs(["schema", tableAlias!, "--aliases", aliasesFilePath])
+      .command(mod)
+      .parse();
+
+    const value = consoleLog.getCall(0).firstArg;
+    equal(value, `{"columns":[{"name":"id","type":"int"}]}`);
   });
 });

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -155,6 +155,71 @@ describe("commands/schema", function () {
     equal(res, `{"columns":[{"name":"counter","type":"integer"}]}`);
   });
 
+  test("passes with valid ENS name when invalid alias provided", async function () {
+    // Must do initial ENS setup and set the record name to the table
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    stub(ensLib, "ENS").callsFake(function () {
+      return {
+        withProvider: () => {
+          return {
+            setRecords: async () => {
+              return false;
+            },
+          };
+        },
+      };
+    });
+    stub(
+      ethers.providers.JsonRpcProvider.prototype,
+      "getResolver"
+      // @ts-ignore
+    ).callsFake(getResolverMock);
+
+    const consoleLog = spy(logger, "log");
+    await yargs([
+      "namespace",
+      "set",
+      "foo.bar.eth",
+      "healthbot=healthbot_31337_1",
+      "--enableEnsExperiment",
+      "--ensProviderUrl",
+      "https://localhost:7070",
+    ])
+      .command(ns)
+      .parse();
+
+    let res = consoleLog.getCall(0).firstArg;
+    const value = JSON.parse(res);
+    equal(value.domain, "foo.bar.eth");
+    equal(value.records[0].key, "healthbot");
+    equal(value.records[0].value, "healthbot_31337_1");
+
+    // Create an empty aliases file
+    const aliasesFilePath = await temporaryWrite(`{}`, {
+      extension: "json",
+    });
+
+    // Now, check the table info using ENS as the name
+    await yargs([
+      "schema",
+      "foo.bar.eth",
+      "--chain",
+      "local-tableland",
+      "--baseUrl",
+      "http://localhost:8080/api/v1",
+      "--enableEnsExperiment",
+      "--ensProviderUrl",
+      "https://localhost:7070",
+      "--aliases",
+      aliasesFilePath,
+    ])
+      .command(mod)
+      .parse();
+
+    res = consoleLog.getCall(1).firstArg;
+    equal(res, `{"columns":[{"name":"counter","type":"integer"}]}`);
+  });
+
   test("passes with table aliases", async function () {
     const [account] = getAccounts();
     // Set up test aliases file

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -11,7 +11,7 @@ const getTimeoutFactor = function (): number {
 
 export const TEST_TIMEOUT_FACTOR = getTimeoutFactor();
 
-const lt = new LocalTableland({ silent: false });
+const lt = new LocalTableland({ silent: true });
 
 before(async function () {
   this.timeout(30000);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -11,7 +11,7 @@ const getTimeoutFactor = function (): number {
 
 export const TEST_TIMEOUT_FACTOR = getTimeoutFactor();
 
-const lt = new LocalTableland({ silent: true });
+const lt = new LocalTableland({ silent: false });
 
 before(async function () {
   this.timeout(30000);

--- a/test/shell.test.ts
+++ b/test/shell.test.ts
@@ -277,7 +277,7 @@ describe("commands/shell", function () {
     equal(value, "missing required flag (`-c` or `--chain`)");
   });
 
-  test("Shell throws with invalid chain", async function () {
+  test("throws with invalid chain", async function () {
     const privateKey = accounts[0].privateKey.slice(2);
     const consoleError = spy(logger, "error");
     await yargs(["shell", "--privateKey", privateKey, "--chain", "foozbazz"])
@@ -288,7 +288,7 @@ describe("commands/shell", function () {
     equal(value, "unsupported chain (see `chains` command for details)");
   });
 
-  test("Custom baseUrl is called", async function () {
+  test("works when custom baseUrl is called", async function () {
     const stdin = mockStd.stdin();
     const fetchSpy = spy(global, "fetch");
 
@@ -428,7 +428,7 @@ SQL Queries can be multi-line, and must end with a semicolon (;)`
     );
   });
 
-  test("passes using table alias with creates, writes, reads", async function () {
+  test("works using table alias with creates, writes, reads", async function () {
     const consoleLog = spy(logger, "log");
     const stdin = mockStd.stdin();
     // Set up test aliases file
@@ -486,5 +486,27 @@ SQL Queries can be multi-line, and must end with a semicolon (;)`
     res = consoleLog.getCall(7).args[0];
     filter = res.replace("tableland> ", "");
     deepStrictEqual(filter, '[{"id":1}]');
+  });
+
+  test("fails with invalid table alias file", async function () {
+    const consoleError = spy(logger, "error");
+    // Set up faux aliases file
+    const aliasesFilePath = "./invalid.json";
+
+    const privateKey = accounts[0].privateKey.slice(2);
+    await yargs([
+      "shell",
+      "--chain",
+      "local-tableland",
+      "--privateKey",
+      privateKey,
+      "--aliases",
+      aliasesFilePath,
+    ])
+      .command(mod)
+      .parse();
+
+    const res = consoleError.getCall(0).args[0];
+    equal(res, "invalid table aliases file");
   });
 });

--- a/test/shell.test.ts
+++ b/test/shell.test.ts
@@ -288,6 +288,28 @@ describe("commands/shell", function () {
     equal(value, "unsupported chain (see `chains` command for details)");
   });
 
+  test("throws with invalid table aliases file", async function () {
+    const consoleError = spy(logger, "error");
+    // Set up faux aliases file
+    const aliasesFilePath = "./invalid.json";
+
+    const privateKey = accounts[0].privateKey.slice(2);
+    await yargs([
+      "shell",
+      "--chain",
+      "local-tableland",
+      "--privateKey",
+      privateKey,
+      "--aliases",
+      aliasesFilePath,
+    ])
+      .command(mod)
+      .parse();
+
+    const res = consoleError.getCall(0).args[0];
+    equal(res, "invalid table aliases file");
+  });
+
   test("works when custom baseUrl is called", async function () {
     const stdin = mockStd.stdin();
     const fetchSpy = spy(global, "fetch");
@@ -428,11 +450,11 @@ SQL Queries can be multi-line, and must end with a semicolon (;)`
     );
   });
 
-  test("works using table alias with creates, writes, reads", async function () {
+  test("works with table aliases (creates, writes, reads)", async function () {
     const consoleLog = spy(logger, "log");
     const stdin = mockStd.stdin();
     // Set up test aliases file
-    const aliasesFilePath = await temporaryWrite(`{}`);
+    const aliasesFilePath = await temporaryWrite(`{}`, { extension: "json" });
 
     // First, create a table
     setTimeout(() => {
@@ -486,27 +508,5 @@ SQL Queries can be multi-line, and must end with a semicolon (;)`
     res = consoleLog.getCall(7).args[0];
     filter = res.replace("tableland> ", "");
     deepStrictEqual(filter, '[{"id":1}]');
-  });
-
-  test("fails with invalid table alias file", async function () {
-    const consoleError = spy(logger, "error");
-    // Set up faux aliases file
-    const aliasesFilePath = "./invalid.json";
-
-    const privateKey = accounts[0].privateKey.slice(2);
-    await yargs([
-      "shell",
-      "--chain",
-      "local-tableland",
-      "--privateKey",
-      privateKey,
-      "--aliases",
-      aliasesFilePath,
-    ])
-      .command(mod)
-      .parse();
-
-    const res = consoleError.getCall(0).args[0];
-    equal(res, "invalid table aliases file");
   });
 });

--- a/test/transfer.test.ts
+++ b/test/transfer.test.ts
@@ -200,15 +200,14 @@ describe("commands/transfer", function () {
 
     // Check the aliases file was updated and matches with the prefix
     const nameMap = await jsonFileAliases(aliasesFilePath).read();
-    const tableAlias = Object.keys(nameMap).find(
-      (alias) => nameMap[alias] === name
-    );
+    const tableAlias =
+      Object.keys(nameMap).find((alias) => nameMap[alias] === name) ?? "";
     equal(tableAlias, prefix);
 
     // Transfer the table
     await yargs([
       "transfer",
-      tableAlias!,
+      tableAlias,
       account2Address,
       "--privateKey",
       privateKey,

--- a/test/transfer.test.ts
+++ b/test/transfer.test.ts
@@ -2,10 +2,11 @@ import { equal } from "node:assert";
 import { describe, test, afterEach, before } from "mocha";
 import { spy, restore } from "sinon";
 import yargs from "yargs/yargs";
+import { temporaryWrite } from "tempy";
 import { getAccounts, getDatabase } from "@tableland/local";
-import { helpers } from "@tableland/sdk";
+import { helpers, Database } from "@tableland/sdk";
 import * as mod from "../src/commands/transfer.js";
-import { wait, logger } from "../src/utils.js";
+import { jsonFileAliases, logger, wait } from "../src/utils.js";
 
 describe("commands/transfer", function () {
   this.timeout("30s");
@@ -95,8 +96,38 @@ describe("commands/transfer", function () {
     );
   });
 
+  test("throws with invalid table alias", async function () {
+    const [, account1, account2] = accounts;
+    const account2Address = account2.address;
+    const consoleError = spy(logger, "error");
+    const privateKey = account1.privateKey.slice(2);
+    // Set up test aliases file
+    const aliasesFilePath = await temporaryWrite(`{}`, { extension: "json" });
+
+    // Transfer the table
+    await yargs([
+      "transfer",
+      "invalid",
+      account2Address,
+      "--privateKey",
+      privateKey,
+      "--chain",
+      "local-tableland",
+      "--aliases",
+      aliasesFilePath,
+    ])
+      .command(mod)
+      .parse();
+
+    const res = consoleError.getCall(0).firstArg;
+    equal(
+      res,
+      "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
+    );
+  });
+
   // Does transfering table have knock-on effects on other tables?
-  test("Write passes with local-tableland", async function () {
+  test("passes with local-tableland", async function () {
     const [, account1, account2] = accounts;
     const account2Address = account2.address;
     const consoleLog = spy(logger, "log");
@@ -109,6 +140,60 @@ describe("commands/transfer", function () {
       privateKey,
       "--chain",
       "local-tableland",
+    ])
+      .command(mod)
+      .parse();
+
+    const res = consoleLog.getCall(0).firstArg;
+    const value = JSON.parse(res);
+    const { to, from } = value;
+
+    equal(from.toLowerCase(), account1.address.toLowerCase());
+    equal(
+      to.toLowerCase(),
+      helpers.getContractAddress("local-tableland").toLowerCase()
+    );
+  });
+
+  test("passes with table alias", async function () {
+    const [, account1, account2] = accounts;
+    const account2Address = account2.address;
+    const consoleLog = spy(logger, "log");
+    const privateKey = account1.privateKey.slice(2);
+    // Set up test aliases file
+    const aliasesFilePath = await temporaryWrite(`{}`, { extension: "json" });
+
+    // Create new db instance to enable aliases
+    const db = new Database({
+      signer: account1,
+      baseUrl: helpers.getBaseUrl("local-tableland"),
+      autoWait: true,
+      aliases: jsonFileAliases(aliasesFilePath),
+    });
+    const { meta } = await db
+      .prepare("CREATE TABLE table_aliases (id int);")
+      .all();
+    const name = meta.txn?.name ?? "";
+    const prefix = meta.txn?.prefix ?? "";
+
+    // Check the aliases file was updated and matches with the prefix
+    const nameMap = await jsonFileAliases(aliasesFilePath).read();
+    const tableAlias = Object.keys(nameMap).find(
+      (alias) => nameMap[alias] === name
+    );
+    equal(tableAlias, prefix);
+
+    // Transfer the table
+    await yargs([
+      "transfer",
+      tableAlias!,
+      account2Address,
+      "--privateKey",
+      privateKey,
+      "--chain",
+      "local-tableland",
+      "--aliases",
+      aliasesFilePath,
     ])
       .command(mod)
       .parse();

--- a/test/transfer.test.ts
+++ b/test/transfer.test.ts
@@ -96,7 +96,32 @@ describe("commands/transfer", function () {
     );
   });
 
-  test("throws with invalid table alias", async function () {
+  test("throws with invalid table aliases file", async function () {
+    const [, account1, account2] = accounts;
+    const account2Address = account2.address;
+    const consoleError = spy(logger, "error");
+    const privateKey = account1.privateKey.slice(2);
+
+    // Transfer the table
+    await yargs([
+      "transfer",
+      "invalid",
+      account2Address,
+      "--privateKey",
+      privateKey,
+      "--chain",
+      "local-tableland",
+      "--aliases",
+      "./invalid.json",
+    ])
+      .command(mod)
+      .parse();
+
+    const res = consoleError.getCall(0).firstArg;
+    equal(res, "invalid table aliases file");
+  });
+
+  test("throws with invalid table alias definition", async function () {
     const [, account1, account2] = accounts;
     const account2Address = account2.address;
     const consoleError = spy(logger, "error");
@@ -120,10 +145,7 @@ describe("commands/transfer", function () {
       .parse();
 
     const res = consoleError.getCall(0).firstArg;
-    equal(
-      res,
-      "invalid table name (name format is `{prefix}_{chainId}_{tableId}`)"
-    );
+    equal(res, "error validating name: table name has wrong format: invalid");
   });
 
   // Does transfering table have knock-on effects on other tables?

--- a/test/write.test.ts
+++ b/test/write.test.ts
@@ -182,7 +182,7 @@ describe("commands/write", function () {
     );
   });
 
-  test("throws with invalid table alias file", async function () {
+  test("throws with invalid table aliases file", async function () {
     const [account] = accounts;
     const privateKey = account.privateKey.slice(2);
     const consoleError = spy(logger, "error");
@@ -204,6 +204,30 @@ describe("commands/write", function () {
 
     const res = consoleError.getCall(0).firstArg;
     equal(res, "invalid table aliases file");
+  });
+
+  test("throws with invalid table alias definition", async function () {
+    const [account] = accounts;
+    const privateKey = account.privateKey.slice(2);
+    const consoleError = spy(logger, "error");
+    // Set up faux aliases file
+    const aliasesFilePath = await temporaryWrite(`{}`, { extension: "json" });
+
+    await yargs([
+      "write",
+      "INSERT INTO table_aliases (id) VALUES (1);",
+      "--chain",
+      "local-tableland",
+      "--privateKey",
+      privateKey,
+      "--aliases",
+      aliasesFilePath,
+    ])
+      .command(mod)
+      .parse();
+
+    const res = consoleError.getCall(0).firstArg;
+    match(res, /error validating name: table name has wrong format:/);
   });
 
   test("passes when writing with local-tableland", async function () {

--- a/test/write.test.ts
+++ b/test/write.test.ts
@@ -591,4 +591,28 @@ describe("commands/write", function () {
     equal(results.length, 1);
     equal(results[0].id, 1);
   });
+
+  test("fails with invalid table alias file", async function () {
+    const [account] = accounts;
+    const privateKey = account.privateKey.slice(2);
+    const consoleError = spy(logger, "error");
+    // Set up faux aliases file
+    const aliasesFilePath = "./invalid.json";
+
+    await yargs([
+      "write",
+      "INSERT INTO table_aliases (id) VALUES (1);",
+      "--chain",
+      "local-tableland",
+      "--privateKey",
+      privateKey,
+      "--aliases",
+      aliasesFilePath,
+    ])
+      .command(mod)
+      .parse();
+
+    const res = consoleError.getCall(0).firstArg;
+    equal(res, "invalid table aliases file");
+  });
 });

--- a/test/write.test.ts
+++ b/test/write.test.ts
@@ -604,9 +604,8 @@ describe("commands/write", function () {
 
     // Check the aliases file was updated and matches with the prefix
     const nameMap = await jsonFileAliases(aliasesFilePath).read();
-    const tableAlias = Object.keys(nameMap).find(
-      (alias) => nameMap[alias] === name
-    );
+    const tableAlias =
+      Object.keys(nameMap).find((alias) => nameMap[alias] === name) ?? "";
     equal(tableAlias, prefix);
 
     // Write to the table using the alias
@@ -630,7 +629,7 @@ describe("commands/write", function () {
 
     equal(typeof transactionHash, "string");
     equal(transactionHash.startsWith("0x"), true);
-    equal(!link, true);
+    equal(link != null, true);
 
     // Make sure data was materialized (note aliases aren't enabled on `db`)
     const { results } = await db
@@ -666,12 +665,10 @@ describe("commands/write", function () {
 
     // Check the aliases file was updated and matches with the prefix
     const nameMap = await jsonFileAliases(aliasesFilePath).read();
-    const tableAlias1 = Object.keys(nameMap).find(
-      (alias) => nameMap[alias] === tableName1
-    );
-    const tableAlias2 = Object.keys(nameMap).find(
-      (alias) => nameMap[alias] === tableName2
-    );
+    const tableAlias1 =
+      Object.keys(nameMap).find((alias) => nameMap[alias] === tableName1) ?? "";
+    const tableAlias2 =
+      Object.keys(nameMap).find((alias) => nameMap[alias] === tableName2) ?? "";
     equal(tableAlias1, tablePrefix1);
     equal(tableAlias2, tablePrefix2);
 

--- a/test/write.test.ts
+++ b/test/write.test.ts
@@ -629,7 +629,7 @@ describe("commands/write", function () {
 
     equal(typeof transactionHash, "string");
     equal(transactionHash.startsWith("0x"), true);
-    equal(link != null, true);
+    equal(link, undefined);
 
     // Make sure data was materialized (note aliases aren't enabled on `db`)
     const { results } = await db


### PR DESCRIPTION
## Summary

Adds the ability to use table aliases in `create`, `write`, and `read` commands, including the `shell`, and also configure a file path with `init`. Closes https://github.com/tablelandnetwork/js-tableland-cli/issues/403.

Edit: also includes support for `controller`, `schema`, and `info`.

## Details

- Adds a global `--aliases`, `-a` option where you specify a JSON file path (checks for validity) or reads from `TBL_ALIASES` / `.tablelandrc.json`.
- `init` provides the ability to, optionally, configure the path to an existing table aliases file or create a new file at a specified directory path—thus, accessible in `.tablelandrc.json`. _Creating_ an aliases file is only possible with `init` and defaults to the name `tableland.aliases.json` in the supplied dir path.
- For example, you can create a table like the following and subsequently use `mytable` in read/write commands:
   ```
   tableland create "CREATE TABLE mytable (id INT);" -a ./tableland.aliases.json
   tableland write "INSERT INTO mytable VALUES (1);" -a ./tableland.aliases.json
   tableland read "SELECT * FROM mytable;" -a ./tableland.aliases.json
   ```
- Same logic applies to the shell and the others mentioned above. No more typing out `prefix_chainId_tableId`! And the shell will log the alias name after each command, along with the existing setup that logs the table name.

## How it was tested

Added tests for `create`, `write`, `read`, `shell`, `controller`, `info`, and `schema` that check for passing a valid aliases file, the updates to it, and also cases where an invalid path is provided. To make sure the logic work, I also added ENS tests where there was potential conflicting logic with aliases.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
